### PR TITLE
Fix coupon field in subscription requests

### DIFF
--- a/app/api/shared_schemas/subscription.py
+++ b/app/api/shared_schemas/subscription.py
@@ -14,7 +14,7 @@ class RequestSubscription(GenericModel):
     period: SubscriptionPeriodEnum = Field(default=SubscriptionPeriodEnum.ANUALLY, example=False)
     organization_id: str= Field(example="org_123")
     allow_additional: bool = Field(default=False, example=False)
-    cupoun_id: str | None = Field(default=None, example="cou_123")
+    coupon_id: str | None = Field(default=None, example="cou_123")
 
     def get_sub_months(self) -> int:
         months_quantity = {

--- a/app/builder/subscriptions.py
+++ b/app/builder/subscriptions.py
@@ -78,18 +78,18 @@ class SubscriptionBuilder:
         # Aplica desconto de cupom, se fornecido
         discount = 0
         observation = {}
-        if subscription.cupoun_id:
+        if subscription.coupon_id:
             coupon_in_db = await self.__coupon_service.search_by_id(
-                id=subscription.cupoun_id
+                id=subscription.coupon_id
             )
             coupon_in_db = await self.__coupon_service.update_usage(
                 coupon_id=coupon_in_db.id, quantity=1
             )
             discount = coupon_in_db.calculate_discount(price=subscription_price)
             observation["discount"] = discount
-            observation["coupon_id"] = subscription.cupoun_id
+            observation["coupon_id"] = subscription.coupon_id
             _logger.info(
-                f"Desconto de R${discount} aplicado usando cupom {subscription.cupoun_id}"
+                f"Desconto de R${discount} aplicado usando cupom {subscription.coupon_id}"
             )
 
         # Gera a preferência de pagamento e a fatura


### PR DESCRIPTION
## Summary
- rename `cupoun_id` to `coupon_id` in shared schema
- update subscription builder to reference `coupon_id`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_684b95b5e56c832ab0f2dd0d084b8e82