### PR TITLE
Add expense service unit tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+import os
+
+ENV_VARS = {
+    "AUTH0_DOMAIN": "test",
+    "AUTH0_API_AUDIENCE": "test",
+    "AUTH0_ISSUER": "test",
+    "AUTH0_ALGORITHMS": "HS256",
+    "AUTH0_CLIENT_ID": "test",
+    "AUTH0_CLIENT_SECRET": "test",
+    "APP_SECRET_KEY": "test",
+    "AUTH0_MANAGEMENT_API_CLIENT_ID": "test",
+    "AUTH0_MANAGEMENT_API_CLIENT_SECRET": "test",
+    "AUTH0_MANAGEMENT_API_AUDIENCE": "test",
+}
+
+for key, value in ENV_VARS.items():
+    os.environ.setdefault(key, value)

--- a/tests/crud/expenses/test_repositories.py
+++ b/tests/crud/expenses/test_repositories.py
@@ -1,0 +1,233 @@
+import pytest
+
+from app.crud.expenses.repositories import ExpenseRepository
+from app.crud.expenses.schemas import Expense, ExpenseInDB
+from app.core.exceptions import NotFoundError, UnprocessableEntity
+from app.crud.shared_schemas.payment import Payment, PaymentMethod
+from app.core.utils.utc_datetime import UTCDateTime
+
+
+class DummyExpenseModel:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+        self.saved = False
+        self.deleted = False
+
+    def save(self):
+        self.saved = True
+
+    def update(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+    def delete(self):
+        self.deleted = True
+
+
+class DummyQuerySet:
+    def __init__(self, result=None, count_value=0, iterable=None):
+        self.result = result
+        self.count_value = count_value
+        self.iterable = iterable or ([result] if result else [])
+
+    def first(self):
+        return self.result
+
+    def count(self):
+        return self.count_value
+
+    def filter(self, **kwargs):
+        return self
+
+    def order_by(self, *args, **kwargs):
+        return self
+
+    def skip(self, val):
+        self.iterable = self.iterable[val:]
+        return self
+
+    def limit(self, val):
+        self.iterable = self.iterable[:val]
+        return self
+
+    def __iter__(self):
+        return iter(self.iterable)
+
+
+def patch_model(monkeypatch, result=None, count_value=0, iterable=None):
+    def objects(**kwargs):
+        return DummyQuerySet(result=result, count_value=count_value, iterable=iterable)
+
+    monkeypatch.setattr("app.crud.expenses.repositories.ExpenseModel", DummyExpenseModel)
+    monkeypatch.setattr(DummyExpenseModel, "objects", staticmethod(objects))
+
+
+@pytest.mark.asyncio
+async def test_create_success(monkeypatch):
+    repo = ExpenseRepository(organization_id="org")
+    patch_model(monkeypatch)
+    expense = Expense(
+        name="market",
+        expense_date=UTCDateTime.now(),
+        payment_details=[Payment(method=PaymentMethod.CASH, payment_date=UTCDateTime.now(), amount=10)],
+        tags=[],
+    )
+    result = await repo.create(expense=expense, total_paid=10)
+    assert isinstance(result, ExpenseInDB)
+    assert result.name == "Market"
+
+
+@pytest.mark.asyncio
+async def test_create_error(monkeypatch):
+    class ErrorModel(DummyExpenseModel):
+        def save(self):
+            raise Exception("db error")
+
+    monkeypatch.setattr("app.crud.expenses.repositories.ExpenseModel", ErrorModel)
+    repo = ExpenseRepository(organization_id="org")
+    expense = Expense(name="market", expense_date=UTCDateTime.now(), payment_details=[], tags=[])
+    with pytest.raises(UnprocessableEntity):
+        await repo.create(expense=expense, total_paid=10)
+
+
+@pytest.mark.asyncio
+async def test_update_success(monkeypatch):
+    existing = DummyExpenseModel(id="e1", name="Store", organization_id="org", expense_date=UTCDateTime.now(), total_paid=5)
+
+    patch_model(monkeypatch, result=existing)
+    repo = ExpenseRepository(organization_id="org")
+    expense_in_db = ExpenseInDB(id="e1", organization_id="org", name="New", expense_date=existing.expense_date, payment_details=[], tags=[], total_paid=20, created_at=UTCDateTime.now(), updated_at=UTCDateTime.now())
+    result = await repo.update(expense=expense_in_db)
+    assert isinstance(result, ExpenseInDB)
+    assert existing.name == "New"
+
+
+@pytest.mark.asyncio
+async def test_update_error(monkeypatch):
+    class ErrorModel(DummyExpenseModel):
+        def update(self, **kwargs):
+            raise Exception("db error")
+
+    existing = ErrorModel(id="e1", name="Store", organization_id="org", expense_date=UTCDateTime.now(), total_paid=5)
+
+    def objects(**kwargs):
+        return DummyQuerySet(result=existing)
+
+    monkeypatch.setattr("app.crud.expenses.repositories.ExpenseModel", ErrorModel)
+    monkeypatch.setattr(ErrorModel, "objects", staticmethod(objects))
+
+    repo = ExpenseRepository(organization_id="org")
+    expense_in_db = ExpenseInDB(id="e1", organization_id="org", name="New", expense_date=existing.expense_date, payment_details=[], tags=[], total_paid=20, created_at=UTCDateTime.now(), updated_at=UTCDateTime.now())
+
+    with pytest.raises(UnprocessableEntity):
+        await repo.update(expense=expense_in_db)
+
+
+@pytest.mark.asyncio
+async def test_select_count_by_date(monkeypatch):
+    patch_model(monkeypatch, count_value=4)
+    repo = ExpenseRepository(organization_id="org")
+    start = UTCDateTime.now()
+    end = UTCDateTime.now()
+    result = await repo.select_count_by_date(start_date=start, end_date=end)
+    assert result == 4
+
+
+@pytest.mark.asyncio
+async def test_select_count_by_date_error(monkeypatch):
+    def objects(**kwargs):
+        raise Exception("db error")
+
+    monkeypatch.setattr("app.crud.expenses.repositories.ExpenseModel", DummyExpenseModel)
+    monkeypatch.setattr(DummyExpenseModel, "objects", staticmethod(objects))
+
+    repo = ExpenseRepository(organization_id="org")
+    start = UTCDateTime.now()
+    end = UTCDateTime.now()
+    result = await repo.select_count_by_date(start_date=start, end_date=end)
+    assert result == 0
+
+
+@pytest.mark.asyncio
+async def test_select_count(monkeypatch):
+    patch_model(monkeypatch, count_value=3)
+    repo = ExpenseRepository(organization_id="org")
+    result = await repo.select_count(query="a")
+    assert result == 3
+
+
+@pytest.mark.asyncio
+async def test_select_count_error(monkeypatch):
+    def objects(**kwargs):
+        raise Exception("db error")
+
+    monkeypatch.setattr("app.crud.expenses.repositories.ExpenseModel", DummyExpenseModel)
+    monkeypatch.setattr(DummyExpenseModel, "objects", staticmethod(objects))
+    repo = ExpenseRepository(organization_id="org")
+    result = await repo.select_count()
+    assert result == 0
+
+
+@pytest.mark.asyncio
+async def test_select_by_id(monkeypatch):
+    existing = DummyExpenseModel(id="e1", name="Store", organization_id="org", expense_date=UTCDateTime.now(), total_paid=10)
+    patch_model(monkeypatch, result=existing)
+    repo = ExpenseRepository(organization_id="org")
+    result = await repo.select_by_id(id="e1")
+    assert isinstance(result, ExpenseInDB)
+    assert result.id == "e1"
+
+
+@pytest.mark.asyncio
+async def test_select_by_id_error(monkeypatch):
+    def objects(**kwargs):
+        raise Exception("db error")
+
+    monkeypatch.setattr("app.crud.expenses.repositories.ExpenseModel", DummyExpenseModel)
+    monkeypatch.setattr(DummyExpenseModel, "objects", staticmethod(objects))
+    repo = ExpenseRepository(organization_id="org")
+    with pytest.raises(NotFoundError):
+        await repo.select_by_id(id="x")
+
+
+@pytest.mark.asyncio
+async def test_select_all(monkeypatch):
+    obj1 = DummyExpenseModel(id="e1", name="Store", organization_id="org", expense_date=UTCDateTime.now(), total_paid=5)
+    obj2 = DummyExpenseModel(id="e2", name="Shop", organization_id="org", expense_date=UTCDateTime.now(), total_paid=15)
+    patch_model(monkeypatch, iterable=[obj1, obj2])
+    repo = ExpenseRepository(organization_id="org")
+    result = await repo.select_all(query="", page=None, page_size=None)
+    assert len(result) == 2
+
+
+@pytest.mark.asyncio
+async def test_select_all_error(monkeypatch):
+    def objects(**kwargs):
+        raise Exception("db error")
+
+    monkeypatch.setattr("app.crud.expenses.repositories.ExpenseModel", DummyExpenseModel)
+    monkeypatch.setattr(DummyExpenseModel, "objects", staticmethod(objects))
+    repo = ExpenseRepository(organization_id="org")
+    with pytest.raises(NotFoundError):
+        await repo.select_all(query="")
+
+
+@pytest.mark.asyncio
+async def test_delete_by_id(monkeypatch):
+    existing = DummyExpenseModel(id="e1", name="Store", organization_id="org", expense_date=UTCDateTime.now(), total_paid=10)
+    patch_model(monkeypatch, result=existing)
+    repo = ExpenseRepository(organization_id="org")
+    result = await repo.delete_by_id(id="e1")
+    assert existing.deleted is True
+    assert result.id == "e1"
+
+
+@pytest.mark.asyncio
+async def test_delete_by_id_error(monkeypatch):
+    def objects(**kwargs):
+        raise Exception("db error")
+
+    monkeypatch.setattr("app.crud.expenses.repositories.ExpenseModel", DummyExpenseModel)
+    monkeypatch.setattr(DummyExpenseModel, "objects", staticmethod(objects))
+    repo = ExpenseRepository(organization_id="org")
+    with pytest.raises(NotFoundError):
+        await repo.delete_by_id(id="x")

--- a/tests/crud/expenses/test_repositories.py
+++ b/tests/crud/expenses/test_repositories.py
@@ -1,233 +1,252 @@
+import os
+
 import pytest
+import mongomock
+from mongoengine import connect, disconnect
 
 from app.crud.expenses.repositories import ExpenseRepository
 from app.crud.expenses.schemas import Expense, ExpenseInDB
+from app.crud.expenses.models import ExpenseModel
 from app.core.exceptions import NotFoundError, UnprocessableEntity
 from app.crud.shared_schemas.payment import Payment, PaymentMethod
 from app.core.utils.utc_datetime import UTCDateTime
 
 
-class DummyExpenseModel:
-    def __init__(self, **kwargs):
-        self.__dict__.update(kwargs)
-        self.saved = False
-        self.deleted = False
-
-    def save(self):
-        self.saved = True
-
-    def update(self, **kwargs):
-        self.__dict__.update(kwargs)
-
-    def delete(self):
-        self.deleted = True
+@pytest.fixture(autouse=True)
+def mongo_connection():
+    connect(
+        "mongoenginetest",
+        host="mongodb://localhost",
+        mongo_client_class=mongomock.MongoClient,
+    )
+    yield
+    ExpenseModel.drop_collection()
+    disconnect()
 
 
-class DummyQuerySet:
-    def __init__(self, result=None, count_value=0, iterable=None):
-        self.result = result
-        self.count_value = count_value
-        self.iterable = iterable or ([result] if result else [])
-
-    def first(self):
-        return self.result
-
-    def count(self):
-        return self.count_value
-
-    def filter(self, **kwargs):
-        return self
-
-    def order_by(self, *args, **kwargs):
-        return self
-
-    def skip(self, val):
-        self.iterable = self.iterable[val:]
-        return self
-
-    def limit(self, val):
-        self.iterable = self.iterable[:val]
-        return self
-
-    def __iter__(self):
-        return iter(self.iterable)
-
-
-def patch_model(monkeypatch, result=None, count_value=0, iterable=None):
-    def objects(**kwargs):
-        return DummyQuerySet(result=result, count_value=count_value, iterable=iterable)
-
-    monkeypatch.setattr("app.crud.expenses.repositories.ExpenseModel", DummyExpenseModel)
-    monkeypatch.setattr(DummyExpenseModel, "objects", staticmethod(objects))
+@pytest.fixture
+def repo():
+    return ExpenseRepository(organization_id="org")
 
 
 @pytest.mark.asyncio
-async def test_create_success(monkeypatch):
-    repo = ExpenseRepository(organization_id="org")
-    patch_model(monkeypatch)
+async def test_create_success(repo):
     expense = Expense(
         name="market",
         expense_date=UTCDateTime.now(),
-        payment_details=[Payment(method=PaymentMethod.CASH, payment_date=UTCDateTime.now(), amount=10)],
+        payment_details=[
+            Payment(method=PaymentMethod.CASH, payment_date=UTCDateTime.now(), amount=10)
+        ],
         tags=[],
     )
     result = await repo.create(expense=expense, total_paid=10)
     assert isinstance(result, ExpenseInDB)
     assert result.name == "Market"
+    assert ExpenseModel.objects(id=result.id).first() is not None
 
 
 @pytest.mark.asyncio
-async def test_create_error(monkeypatch):
-    class ErrorModel(DummyExpenseModel):
-        def save(self):
-            raise Exception("db error")
+async def test_create_error(monkeypatch, repo):
+    def raise_save(self):
+        raise Exception("db error")
 
-    monkeypatch.setattr("app.crud.expenses.repositories.ExpenseModel", ErrorModel)
-    repo = ExpenseRepository(organization_id="org")
-    expense = Expense(name="market", expense_date=UTCDateTime.now(), payment_details=[], tags=[])
+    monkeypatch.setattr(ExpenseModel, "save", raise_save)
+    expense = Expense(
+        name="market",
+        expense_date=UTCDateTime.now(),
+        payment_details=[],
+        tags=[],
+    )
     with pytest.raises(UnprocessableEntity):
         await repo.create(expense=expense, total_paid=10)
 
 
 @pytest.mark.asyncio
-async def test_update_success(monkeypatch):
-    existing = DummyExpenseModel(id="e1", name="Store", organization_id="org", expense_date=UTCDateTime.now(), total_paid=5)
+async def test_update_success(repo):
+    existing = ExpenseModel(
+        organization_id="org",
+        name="store",
+        expense_date=UTCDateTime.now(),
+        total_paid=5,
+    )
+    existing.save()
 
-    patch_model(monkeypatch, result=existing)
-    repo = ExpenseRepository(organization_id="org")
-    expense_in_db = ExpenseInDB(id="e1", organization_id="org", name="New", expense_date=existing.expense_date, payment_details=[], tags=[], total_paid=20, created_at=UTCDateTime.now(), updated_at=UTCDateTime.now())
+    expense_in_db = ExpenseInDB(
+        id=existing.id,
+        organization_id="org",
+        name="New",
+        expense_date=existing.expense_date,
+        payment_details=[],
+        tags=[],
+        total_paid=20,
+        created_at=existing.created_at,
+        updated_at=existing.updated_at,
+    )
     result = await repo.update(expense=expense_in_db)
     assert isinstance(result, ExpenseInDB)
-    assert existing.name == "New"
+    assert ExpenseModel.objects(id=existing.id).first().name == "New"
 
 
 @pytest.mark.asyncio
-async def test_update_error(monkeypatch):
-    class ErrorModel(DummyExpenseModel):
-        def update(self, **kwargs):
-            raise Exception("db error")
+async def test_update_error(monkeypatch, repo):
+    existing = ExpenseModel(
+        organization_id="org",
+        name="store",
+        expense_date=UTCDateTime.now(),
+        total_paid=5,
+    )
+    existing.save()
 
-    existing = ErrorModel(id="e1", name="Store", organization_id="org", expense_date=UTCDateTime.now(), total_paid=5)
+    def raise_update(self, **kwargs):
+        raise Exception("db error")
 
-    def objects(**kwargs):
-        return DummyQuerySet(result=existing)
+    monkeypatch.setattr(ExpenseModel, "update", raise_update)
 
-    monkeypatch.setattr("app.crud.expenses.repositories.ExpenseModel", ErrorModel)
-    monkeypatch.setattr(ErrorModel, "objects", staticmethod(objects))
-
-    repo = ExpenseRepository(organization_id="org")
-    expense_in_db = ExpenseInDB(id="e1", organization_id="org", name="New", expense_date=existing.expense_date, payment_details=[], tags=[], total_paid=20, created_at=UTCDateTime.now(), updated_at=UTCDateTime.now())
-
+    expense_in_db = ExpenseInDB(
+        id=existing.id,
+        organization_id="org",
+        name="New",
+        expense_date=existing.expense_date,
+        payment_details=[],
+        tags=[],
+        total_paid=20,
+        created_at=existing.created_at,
+        updated_at=existing.updated_at,
+    )
     with pytest.raises(UnprocessableEntity):
         await repo.update(expense=expense_in_db)
 
 
 @pytest.mark.asyncio
-async def test_select_count_by_date(monkeypatch):
-    patch_model(monkeypatch, count_value=4)
-    repo = ExpenseRepository(organization_id="org")
-    start = UTCDateTime.now()
-    end = UTCDateTime.now()
-    result = await repo.select_count_by_date(start_date=start, end_date=end)
+async def test_select_count_by_date(repo):
+    now = UTCDateTime.now()
+    for _ in range(4):
+        ExpenseModel(
+            organization_id="org",
+            name="store",
+            expense_date=now,
+            total_paid=1,
+        ).save()
+
+    result = await repo.select_count_by_date(start_date=now, end_date=now)
     assert result == 4
 
 
 @pytest.mark.asyncio
-async def test_select_count_by_date_error(monkeypatch):
-    def objects(**kwargs):
+async def test_select_count_by_date_error(monkeypatch, repo):
+    def raise_objects(**kwargs):
         raise Exception("db error")
 
-    monkeypatch.setattr("app.crud.expenses.repositories.ExpenseModel", DummyExpenseModel)
-    monkeypatch.setattr(DummyExpenseModel, "objects", staticmethod(objects))
-
-    repo = ExpenseRepository(organization_id="org")
-    start = UTCDateTime.now()
-    end = UTCDateTime.now()
-    result = await repo.select_count_by_date(start_date=start, end_date=end)
+    monkeypatch.setattr(ExpenseModel, "objects", staticmethod(raise_objects))
+    now = UTCDateTime.now()
+    result = await repo.select_count_by_date(start_date=now, end_date=now)
     assert result == 0
 
 
 @pytest.mark.asyncio
-async def test_select_count(monkeypatch):
-    patch_model(monkeypatch, count_value=3)
-    repo = ExpenseRepository(organization_id="org")
+async def test_select_count(repo):
+    ExpenseModel(
+        organization_id="org",
+        name="Alpha",
+        expense_date=UTCDateTime.now(),
+        total_paid=1,
+    ).save()
+    ExpenseModel(
+        organization_id="org",
+        name="Beta",
+        expense_date=UTCDateTime.now(),
+        total_paid=1,
+    ).save()
+
     result = await repo.select_count(query="a")
-    assert result == 3
+    assert result == 2
 
 
 @pytest.mark.asyncio
-async def test_select_count_error(monkeypatch):
-    def objects(**kwargs):
+async def test_select_count_error(monkeypatch, repo):
+    def raise_objects(**kwargs):
         raise Exception("db error")
 
-    monkeypatch.setattr("app.crud.expenses.repositories.ExpenseModel", DummyExpenseModel)
-    monkeypatch.setattr(DummyExpenseModel, "objects", staticmethod(objects))
-    repo = ExpenseRepository(organization_id="org")
+    monkeypatch.setattr(ExpenseModel, "objects", staticmethod(raise_objects))
     result = await repo.select_count()
     assert result == 0
 
 
 @pytest.mark.asyncio
-async def test_select_by_id(monkeypatch):
-    existing = DummyExpenseModel(id="e1", name="Store", organization_id="org", expense_date=UTCDateTime.now(), total_paid=10)
-    patch_model(monkeypatch, result=existing)
-    repo = ExpenseRepository(organization_id="org")
-    result = await repo.select_by_id(id="e1")
+async def test_select_by_id(repo):
+    doc = ExpenseModel(
+        organization_id="org",
+        name="store",
+        expense_date=UTCDateTime.now(),
+        total_paid=5,
+    )
+    doc.save()
+
+    result = await repo.select_by_id(id=doc.id)
     assert isinstance(result, ExpenseInDB)
-    assert result.id == "e1"
+    assert result.id == doc.id
 
 
 @pytest.mark.asyncio
-async def test_select_by_id_error(monkeypatch):
-    def objects(**kwargs):
+async def test_select_by_id_error(monkeypatch, repo):
+    def raise_objects(**kwargs):
         raise Exception("db error")
 
-    monkeypatch.setattr("app.crud.expenses.repositories.ExpenseModel", DummyExpenseModel)
-    monkeypatch.setattr(DummyExpenseModel, "objects", staticmethod(objects))
-    repo = ExpenseRepository(organization_id="org")
+    monkeypatch.setattr(ExpenseModel, "objects", staticmethod(raise_objects))
     with pytest.raises(NotFoundError):
         await repo.select_by_id(id="x")
 
 
 @pytest.mark.asyncio
-async def test_select_all(monkeypatch):
-    obj1 = DummyExpenseModel(id="e1", name="Store", organization_id="org", expense_date=UTCDateTime.now(), total_paid=5)
-    obj2 = DummyExpenseModel(id="e2", name="Shop", organization_id="org", expense_date=UTCDateTime.now(), total_paid=15)
-    patch_model(monkeypatch, iterable=[obj1, obj2])
-    repo = ExpenseRepository(organization_id="org")
+async def test_select_all(repo):
+    ExpenseModel(
+        organization_id="org",
+        name="Store",
+        expense_date=UTCDateTime.now(),
+        total_paid=5,
+    ).save()
+    ExpenseModel(
+        organization_id="org",
+        name="Shop",
+        expense_date=UTCDateTime.now(),
+        total_paid=15,
+    ).save()
+
     result = await repo.select_all(query="", page=None, page_size=None)
     assert len(result) == 2
 
 
 @pytest.mark.asyncio
-async def test_select_all_error(monkeypatch):
-    def objects(**kwargs):
+async def test_select_all_error(monkeypatch, repo):
+    def raise_objects(**kwargs):
         raise Exception("db error")
 
-    monkeypatch.setattr("app.crud.expenses.repositories.ExpenseModel", DummyExpenseModel)
-    monkeypatch.setattr(DummyExpenseModel, "objects", staticmethod(objects))
-    repo = ExpenseRepository(organization_id="org")
+    monkeypatch.setattr(ExpenseModel, "objects", staticmethod(raise_objects))
     with pytest.raises(NotFoundError):
         await repo.select_all(query="")
 
 
 @pytest.mark.asyncio
-async def test_delete_by_id(monkeypatch):
-    existing = DummyExpenseModel(id="e1", name="Store", organization_id="org", expense_date=UTCDateTime.now(), total_paid=10)
-    patch_model(monkeypatch, result=existing)
-    repo = ExpenseRepository(organization_id="org")
-    result = await repo.delete_by_id(id="e1")
-    assert existing.deleted is True
-    assert result.id == "e1"
+async def test_delete_by_id(repo):
+    doc = ExpenseModel(
+        organization_id="org",
+        name="Store",
+        expense_date=UTCDateTime.now(),
+        total_paid=10,
+    )
+    doc.save()
+
+    result = await repo.delete_by_id(id=doc.id)
+    assert result.id == doc.id
+    assert ExpenseModel.objects(id=doc.id).first().is_active is False
 
 
 @pytest.mark.asyncio
-async def test_delete_by_id_error(monkeypatch):
-    def objects(**kwargs):
+async def test_delete_by_id_error(monkeypatch, repo):
+    def raise_objects(**kwargs):
         raise Exception("db error")
 
-    monkeypatch.setattr("app.crud.expenses.repositories.ExpenseModel", DummyExpenseModel)
-    monkeypatch.setattr(DummyExpenseModel, "objects", staticmethod(objects))
-    repo = ExpenseRepository(organization_id="org")
+    monkeypatch.setattr(ExpenseModel, "objects", staticmethod(raise_objects))
     with pytest.raises(NotFoundError):
         await repo.delete_by_id(id="x")
+

--- a/tests/crud/expenses/test_services.py
+++ b/tests/crud/expenses/test_services.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 from unittest.mock import AsyncMock
 

--- a/tests/crud/expenses/test_services.py
+++ b/tests/crud/expenses/test_services.py
@@ -1,0 +1,153 @@
+import pytest
+from unittest.mock import AsyncMock
+
+from app.crud.expenses.services import ExpenseServices
+from app.crud.expenses.schemas import Expense, UpdateExpense, ExpenseInDB
+from app.crud.shared_schemas.payment import Payment, PaymentMethod
+from app.crud.tags.schemas import TagInDB
+from app.core.utils.utc_datetime import UTCDateTime
+
+
+class DummyPlanFeature:
+    def __init__(self, value="-"):
+        self.value = value
+
+
+@pytest.mark.asyncio
+async def test_create_expense(monkeypatch):
+    expense_repo = AsyncMock()
+    tag_repo = AsyncMock()
+    service = ExpenseServices(expense_repository=expense_repo, tag_repository=tag_repo)
+
+    monkeypatch.setattr(
+        "app.crud.expenses.services.get_plan_feature",
+        AsyncMock(return_value=DummyPlanFeature(value="-")),
+    )
+    monkeypatch.setattr(
+        "app.crud.expenses.services.get_start_and_end_day_of_month",
+        lambda: (UTCDateTime.now(), UTCDateTime.now()),
+    )
+
+    expense_repo.select_count_by_date = AsyncMock(return_value=0)
+    tag_repo.select_by_id = AsyncMock(return_value=TagInDB(id="t1", name="Tag", organization_id="org"))
+
+    payment_details = [
+        Payment(method=PaymentMethod.CASH, payment_date=UTCDateTime.now(), amount=60),
+        Payment(method=PaymentMethod.PIX, payment_date=UTCDateTime.now(), amount=40),
+    ]
+    expense = Expense(name="market", expense_date=UTCDateTime.now(), payment_details=payment_details, tags=["t1"])
+
+    created = ExpenseInDB(
+        id="e1",
+        organization_id="org",
+        name="Market",
+        expense_date=expense.expense_date,
+        payment_details=payment_details,
+        tags=["t1"],
+        total_paid=100,
+        created_at=UTCDateTime.now(),
+        updated_at=UTCDateTime.now(),
+    )
+    expense_repo.create = AsyncMock(return_value=created)
+
+    result = await service.create(expense)
+
+    expense_repo.create.assert_awaited_with(expense=expense, total_paid=100)
+    assert result == created
+
+
+@pytest.mark.asyncio
+async def test_create_expense_invalid_total(monkeypatch):
+    expense_repo = AsyncMock()
+    tag_repo = AsyncMock()
+    service = ExpenseServices(expense_repository=expense_repo, tag_repository=tag_repo)
+
+    monkeypatch.setattr(
+        "app.crud.expenses.services.get_plan_feature",
+        AsyncMock(return_value=DummyPlanFeature(value="-")),
+    )
+    monkeypatch.setattr(
+        "app.crud.expenses.services.get_start_and_end_day_of_month",
+        lambda: (UTCDateTime.now(), UTCDateTime.now()),
+    )
+
+    expense_repo.select_count_by_date = AsyncMock(return_value=0)
+    tag_repo.select_by_id = AsyncMock(return_value=TagInDB(id="t1", name="Tag", organization_id="org"))
+
+    payment_details = [
+        Payment(method=PaymentMethod.CASH, payment_date=UTCDateTime.now(), amount=0),
+    ]
+    expense = Expense(name="market", expense_date=UTCDateTime.now(), payment_details=payment_details, tags=["t1"])
+
+    with pytest.raises(Exception):
+        await service.create(expense)
+
+    expense_repo.create.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_update_expense(monkeypatch):
+    expense_repo = AsyncMock()
+    tag_repo = AsyncMock()
+    service = ExpenseServices(expense_repository=expense_repo, tag_repository=tag_repo)
+
+    existing = ExpenseInDB(
+        id="e1",
+        organization_id="org",
+        name="Market",
+        expense_date=UTCDateTime.now(),
+        payment_details=[],
+        tags=[],
+        total_paid=50,
+        created_at=UTCDateTime.now(),
+        updated_at=UTCDateTime.now(),
+    )
+    expense_repo.select_by_id = AsyncMock(return_value=existing)
+
+    payment_details = [
+        Payment(method=PaymentMethod.CASH, payment_date=UTCDateTime.now(), amount=30),
+    ]
+    update = UpdateExpense(payment_details=payment_details)
+
+    updated = ExpenseInDB(
+        id="e1",
+        organization_id="org",
+        name="Market",
+        expense_date=existing.expense_date,
+        payment_details=payment_details,
+        tags=[],
+        total_paid=30,
+        created_at=existing.created_at,
+        updated_at=UTCDateTime.now(),
+    )
+    expense_repo.update = AsyncMock(return_value=updated)
+
+    result = await service.update("e1", update)
+
+    expense_repo.update.assert_awaited()
+    assert result.total_paid == 30
+
+
+@pytest.mark.asyncio
+async def test_delete_expense():
+    expense_repo = AsyncMock()
+    tag_repo = AsyncMock()
+    service = ExpenseServices(expense_repository=expense_repo, tag_repository=tag_repo)
+
+    deleted = ExpenseInDB(
+        id="e1",
+        organization_id="org",
+        name="Market",
+        expense_date=UTCDateTime.now(),
+        payment_details=[],
+        tags=[],
+        total_paid=50,
+        created_at=UTCDateTime.now(),
+        updated_at=UTCDateTime.now(),
+    )
+    expense_repo.delete_by_id = AsyncMock(return_value=deleted)
+
+    result = await service.delete_by_id("e1")
+
+    expense_repo.delete_by_id.assert_awaited_with(id="e1")
+    assert result == deleted


### PR DESCRIPTION
## Summary
- add tests for expense services CRUD logic

## Testing
- `pytest -q` *(fails: No module named 'httpx' and 'sentry_sdk')*

------
https://chatgpt.com/codex/tasks/task_e_684b9648e31c832aa03621b778a025b8