### PR TITLE
Add customer API and CRUD tests

### DIFF
--- a/tests/api/routers/customers/test_customers_command_router.py
+++ b/tests/api/routers/customers/test_customers_command_router.py
@@ -1,0 +1,140 @@
+import unittest
+from bson import ObjectId
+from fastapi.testclient import TestClient
+from mongoengine import connect, disconnect
+import mongomock
+
+from app.api.dependencies.auth import decode_jwt
+from app.api.dependencies.get_current_organization import check_current_organization
+from app.application import app
+from app.core.utils.features import Feature
+from app.core.utils.utc_datetime import UTCDateTime
+from app.crud.plan_features.schemas import PlanFeatureInDB
+from app.crud.customers.models import CustomerModel
+from tests.payloads import USER_IN_DB
+
+
+class TestCustomersCommandRouter(unittest.TestCase):
+    def setUp(self):
+        def override_dependency(mock):
+            def _dependency():
+                return mock
+            return _dependency
+
+        disconnect()
+        connect(mongo_client_class=mongomock.MongoClient)
+
+        self.test_client = TestClient(app)
+
+        app.dependency_overrides[decode_jwt] = override_dependency(USER_IN_DB)
+        app.dependency_overrides[check_current_organization] = override_dependency("org_123")
+
+        self.mock_feature = PlanFeatureInDB(
+            id=str(ObjectId()),
+            additional_price=0,
+            allow_additional=False,
+            display_name="Max customers",
+            display_value="1",
+            name=Feature.MAX_CUSTOMERS,
+            value="2",
+            plan_id=str(ObjectId()),
+            created_at=UTCDateTime.now(),
+            updated_at=UTCDateTime.now(),
+        )
+
+        app.user_middleware.clear()
+
+    def tearDown(self) -> None:
+        disconnect()
+        app.dependency_overrides = {}
+
+    def insert_mock_customer(self, name="Customer"):
+        cust = CustomerModel(
+            name=name,
+            organization_id="org_123",
+            addresses=[],
+            tags=[],
+            created_at=UTCDateTime.now(),
+            updated_at=UTCDateTime.now(),
+            is_active=True,
+        )
+        cust.save()
+        return str(cust.id)
+
+    @unittest.mock.patch("app.crud.customers.services.get_plan_feature")
+    def test_post_customer_success(self, mock_get_plan_feature):
+        mock_get_plan_feature.return_value = self.mock_feature.model_copy(update={"value": "-"})
+        response = self.test_client.post(
+            url="/api/customers",
+            json={"name": "John"},
+            headers={"organization-id": "org_123"},
+        )
+        json = response.json()
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(json["message"], "Cliente criado com sucesso")
+        self.assertIsNotNone(json["data"]["id"])
+        self.assertEqual(json["data"]["name"], "John")
+
+    @unittest.mock.patch("app.crud.customers.services.get_plan_feature")
+    def test_post_customer_failure_due_to_limit(self, mock_get_plan_feature):
+        mock_get_plan_feature.return_value = self.mock_feature.model_copy()
+        self.insert_mock_customer(name="A")
+        self.insert_mock_customer(name="B")
+        response = self.test_client.post(
+            url="/api/customers",
+            json={"name": "C"},
+            headers={"organization-id": "org_123"},
+        )
+        self.assertEqual(response.status_code, 403)
+        self.assertIn("Máximo de clientes", response.json()["message"])
+
+    def test_put_customer_success(self):
+        cust_id = self.insert_mock_customer(name="Old")
+        response = self.test_client.put(
+            f"/api/customers/{cust_id}",
+            json={"name": "Updated"},
+            headers={"organization-id": "org_123"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["message"], "Cliente atualizado com sucesso")
+
+    def test_put_customer_failure(self):
+        response = self.test_client.put(
+            "/api/customers/invalid",
+            json={"name": "Fail"},
+            headers={"organization-id": "org_123"},
+        )
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json()["message"], "Cliente com o ID #invalid não foi encontrado")
+
+    def test_delete_customer_success(self):
+        cust_id = self.insert_mock_customer(name="Del")
+        response = self.test_client.delete(
+            f"/api/customers/{cust_id}", headers={"organization-id": "org_123"}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["message"], "Cliente deletado com sucesso")
+
+    def test_delete_customer_not_found(self):
+        response = self.test_client.delete(
+            "/api/customers/9999", headers={"organization-id": "org_123"}
+        )
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json()["message"], "Cliente com o ID #9999 não foi encontrado")
+
+    def test_post_customer_invalid_payload_returns_422(self):
+        response = self.test_client.post(
+            url="/api/customers",
+            json={"phoneNumber": "123"},
+            headers={"organization-id": "org_123"},
+        )
+        self.assertEqual(response.status_code, 422)
+
+    def test_put_customer_invalid_payload_returns_422(self):
+        cust_id = self.insert_mock_customer(name="Fail")
+        response = self.test_client.put(
+            f"/api/customers/{cust_id}",
+            json={"ddd": "01", "phoneNumber": "abc"},
+            headers={"organization-id": "org_123"},
+        )
+        self.assertEqual(response.status_code, 422)

--- a/tests/api/routers/customers/test_customers_query_router.py
+++ b/tests/api/routers/customers/test_customers_query_router.py
@@ -1,0 +1,114 @@
+import unittest
+from fastapi.testclient import TestClient
+from mongoengine import connect, disconnect
+import mongomock
+
+from app.api.dependencies.auth import decode_jwt
+from app.api.dependencies.get_current_organization import check_current_organization
+from app.application import app
+from app.crud.customers.models import CustomerModel
+from app.core.utils.utc_datetime import UTCDateTime
+from tests.payloads import USER_IN_DB
+
+
+class TestCustomersQueryRouter(unittest.TestCase):
+    def setUp(self):
+        def override_dependency(mock):
+            def _dependency():
+                return mock
+            return _dependency
+
+        disconnect()
+        connect(mongo_client_class=mongomock.MongoClient)
+        self.test_client = TestClient(app)
+
+        app.dependency_overrides[decode_jwt] = override_dependency(USER_IN_DB)
+        app.dependency_overrides[check_current_organization] = override_dependency("org_123")
+        app.user_middleware.clear()
+
+    def tearDown(self) -> None:
+        disconnect()
+        app.dependency_overrides = {}
+
+    def insert_mock_customer(self, name="Customer"):
+        customer = CustomerModel(
+            name=name,
+            organization_id="org_123",
+            addresses=[],
+            tags=[],
+            created_at=UTCDateTime.now(),
+            updated_at=UTCDateTime.now(),
+            is_active=True,
+        )
+        customer.save()
+        return str(customer.id)
+
+    def test_get_customer_by_id_success(self):
+        cust_id = self.insert_mock_customer(name="By ID")
+        response = self.test_client.get(
+            f"/api/customers/{cust_id}",
+            headers={"organization-id": "org_123"}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["data"]["name"], "By ID")
+        self.assertEqual(response.json()["message"], "Cliente encontrado")
+
+    def test_get_customer_by_id_not_found(self):
+        response = self.test_client.get(
+            "/api/customers/000000000000000000000000",
+            headers={"organization-id": "org_123"}
+        )
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(
+            response.json()["message"],
+            "Cliente com o ID #000000000000000000000000 não foi encontrado",
+        )
+
+    def test_get_customers_with_results(self):
+        self.insert_mock_customer(name="A")
+        self.insert_mock_customer(name="B")
+        response = self.test_client.get(
+            "/api/customers",
+            headers={"organization-id": "org_123"}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["message"], "Clientes encontrados com sucesso")
+        self.assertGreaterEqual(len(response.json()["data"]), 2)
+
+    def test_get_customers_empty_returns_204(self):
+        response = self.test_client.get(
+            "/api/customers",
+            headers={"organization-id": "org_123"}
+        )
+        self.assertEqual(response.status_code, 204)
+
+    def test_get_customers_expand_tags(self):
+        from app.crud.tags.models import TagModel
+        tag = TagModel(name="Tag1", organization_id="org_123")
+        tag.save()
+        customer = CustomerModel(
+            name="With Tag",
+            organization_id="org_123",
+            addresses=[],
+            tags=[tag.id],
+            created_at=UTCDateTime.now(),
+            updated_at=UTCDateTime.now(),
+            is_active=True,
+        )
+        customer.save()
+        response = self.test_client.get(
+            "/api/customers?expand=tags",
+            headers={"organization-id": "org_123"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["data"][0]["tags"][0]["name"], "Tag1")
+
+    def test_get_customers_count(self):
+        self.insert_mock_customer(name="One")
+        response = self.test_client.get(
+            "/api/customers/metrics/count",
+            headers={"organization-id": "org_123"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["message"], "Contagem de clientes feita com sucesso")
+        self.assertEqual(response.json()["data"], 1)

--- a/tests/crud/customers/test_customers_repository.py
+++ b/tests/crud/customers/test_customers_repository.py
@@ -1,0 +1,96 @@
+import unittest
+from mongoengine import connect, disconnect
+import mongomock
+
+from app.crud.customers.repositories import CustomerRepository
+from app.crud.customers.schemas import Customer
+from app.crud.customers.models import CustomerModel
+from app.core.exceptions import NotFoundError, UnprocessableEntity
+
+
+class TestCustomerRepository(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        connect(
+            "mongoenginetest",
+            host="mongodb://localhost",
+            mongo_client_class=mongomock.MongoClient,
+            alias="default",
+        )
+        self.repo = CustomerRepository(organization_id="org1")
+
+    def tearDown(self):
+        disconnect()
+
+    async def _customer(self, name="John Doe", email=None, phone=None):
+        data = {
+            "name": name,
+            "addresses": [],
+            "tags": [],
+        }
+        if email:
+            data["email"] = email
+        if phone:
+            data["ddd"] = "047"
+            data["phone_number"] = phone
+        return Customer(**data)
+
+    async def test_create_customer(self):
+        customer = await self._customer(name="Alice")
+        result = await self.repo.create(customer)
+        self.assertEqual(result.name, "Alice")
+        self.assertEqual(CustomerModel.objects.count(), 1)
+
+    async def test_create_duplicate_email_raises_error(self):
+        customer = await self._customer(email="a@test.com")
+        await self.repo.create(customer)
+        with self.assertRaises(UnprocessableEntity):
+            await self.repo.create(await self._customer(name="B", email="a@test.com"))
+
+    async def test_create_duplicate_phone_raises_error(self):
+        customer = await self._customer(phone="9999999")
+        await self.repo.create(customer)
+        with self.assertRaises(UnprocessableEntity):
+            await self.repo.create(await self._customer(name="B", phone="9999999"))
+
+    async def test_update_customer_name(self):
+        created = await self.repo.create(await self._customer(name="Old"))
+        created.name = "New"
+        updated = await self.repo.update(created)
+        self.assertEqual(updated.name, "New")
+
+    async def test_select_by_id_success(self):
+        created = await self.repo.create(await self._customer(name="Find"))
+        result = await self.repo.select_by_id(id=created.id)
+        self.assertEqual(result.id, created.id)
+
+    async def test_select_by_id_not_found(self):
+        with self.assertRaises(NotFoundError):
+            await self.repo.select_by_id(id="missing")
+
+    async def test_select_count_with_query(self):
+        await self.repo.create(await self._customer(name="John"))
+        await self.repo.create(await self._customer(name="Johnny"))
+        await self.repo.create(await self._customer(name="Mark"))
+        count = await self.repo.select_count(query="John")
+        self.assertEqual(count, 2)
+
+    async def test_select_all_with_pagination(self):
+        await self.repo.create(await self._customer(name="A"))
+        await self.repo.create(await self._customer(name="B"))
+        await self.repo.create(await self._customer(name="C"))
+        results = await self.repo.select_all(query=None, page=1, page_size=2)
+        self.assertEqual(len(results), 2)
+        results_p2 = await self.repo.select_all(query=None, page=2, page_size=2)
+        self.assertEqual(len(results_p2), 1)
+        names = {r.name for r in results + results_p2}
+        self.assertEqual(names, {"A", "B", "C"})
+
+    async def test_delete_by_id_success(self):
+        created = await self.repo.create(await self._customer(name="Del"))
+        result = await self.repo.delete_by_id(id=created.id)
+        self.assertEqual(CustomerModel.objects(is_active=True).count(), 0)
+        self.assertEqual(result.name, "Del")
+
+    async def test_delete_by_id_not_found(self):
+        with self.assertRaises(NotFoundError):
+            await self.repo.delete_by_id(id="missing")

--- a/tests/crud/customers/test_customers_schemas.py
+++ b/tests/crud/customers/test_customers_schemas.py
@@ -1,0 +1,24 @@
+import unittest
+from app.crud.customers.schemas import Customer, UpdateCustomer
+
+
+class TestCustomerSchemas(unittest.TestCase):
+    def test_customer_invalid_phone_raises(self):
+        with self.assertRaises(ValueError):
+            Customer(name="A", ddd="aa", phone_number="123")
+
+    def test_customer_invalid_document_length_raises(self):
+        with self.assertRaises(ValueError):
+            Customer(name="B", document="123")
+
+    def test_customer_invalid_email_raises(self):
+        with self.assertRaises(ValueError):
+            Customer(name="C", email="bad_email")
+
+    def test_customer_blank_email_becomes_none(self):
+        cust = Customer(name="D", email="")
+        self.assertIsNone(cust.email)
+
+    def test_update_customer_invalid_email(self):
+        with self.assertRaises(ValueError):
+            UpdateCustomer(email="bad")

--- a/tests/crud/customers/test_customers_services.py
+++ b/tests/crud/customers/test_customers_services.py
@@ -1,0 +1,123 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from mongoengine import connect, disconnect
+import mongomock
+
+from app.crud.customers.repositories import CustomerRepository
+from app.crud.customers.schemas import Customer, CustomerInDB, UpdateCustomer
+from app.crud.customers.services import CustomerServices
+from app.core.utils.utc_datetime import UTCDateTime
+from app.api.exceptions.authentication_exceptions import UnauthorizedException
+
+
+class TestCustomerServices(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        connect(
+            "mongoenginetest",
+            host="mongodb://localhost",
+            mongo_client_class=mongomock.MongoClient,
+            alias="default",
+        )
+        repo = CustomerRepository(organization_id="org1")
+        tag_repo = AsyncMock()
+        self.service = CustomerServices(customer_repository=repo, tag_repository=tag_repo)
+
+    def tearDown(self):
+        disconnect()
+
+    async def _customer(self, name="John"):
+        return Customer(name=name)
+
+    @patch("app.crud.customers.services.get_plan_feature", new_callable=AsyncMock)
+    async def test_create_customer_respects_plan_limit(self, mock_plan):
+        mock_plan.return_value = SimpleNamespace(value="2")
+        await self.service.create(await self._customer())
+        with self.assertRaises(UnauthorizedException):
+            await self.service.create(await self._customer(name="Another"))
+
+    @patch("app.crud.customers.services.get_plan_feature", new_callable=AsyncMock)
+    async def test_create_customer_success(self, mock_plan):
+        mock_plan.return_value = SimpleNamespace(value="-")
+        result = await self.service.create(await self._customer())
+        self.assertEqual(result.name, "John")
+
+    @patch("app.crud.customers.services.get_plan_feature", new_callable=AsyncMock)
+    async def test_update_customer(self, mock_plan):
+        mock_plan.return_value = SimpleNamespace(value="-")
+        created = await self.service.create(await self._customer())
+        updated = await self.service.update(id=created.id, updated_customer=UpdateCustomer(name="New"))
+        self.assertEqual(updated.name, "New")
+
+    async def test_update_without_real_change(self):
+        mock_repo = AsyncMock()
+        mock_repo.select_by_id.return_value = CustomerInDB(
+            id="1", name="Same", organization_id="org1", is_active=True,
+            addresses=[], tags=[],
+            created_at=UTCDateTime.now(), updated_at=UTCDateTime.now()
+        )
+        mock_repo.update.return_value = mock_repo.select_by_id.return_value
+        service = CustomerServices(customer_repository=mock_repo, tag_repository=AsyncMock())
+        result = await service.update(id="1", updated_customer=UpdateCustomer())
+        self.assertEqual(result.name, "Same")
+        mock_repo.update.assert_not_awaited()
+
+    async def test_search_by_id_calls_repo(self):
+        mock_repo = AsyncMock()
+        mock_repo.select_by_id.return_value = CustomerInDB(
+            id="x", name="Cust", organization_id="org1", is_active=True,
+            addresses=[], tags=[], created_at=UTCDateTime.now(), updated_at=UTCDateTime.now()
+        )
+        service = CustomerServices(customer_repository=mock_repo, tag_repository=AsyncMock())
+        result = await service.search_by_id(id="x")
+        self.assertEqual(result.id, "x")
+        mock_repo.select_by_id.assert_awaited_with(id="x")
+
+    async def test_search_all(self):
+        mock_repo = AsyncMock()
+        mock_repo.select_all.return_value = [
+            CustomerInDB(
+                id="1", name="A", organization_id="org1", is_active=True,
+                addresses=[], tags=[], created_at=UTCDateTime.now(), updated_at=UTCDateTime.now()
+            )
+        ]
+        service = CustomerServices(customer_repository=mock_repo, tag_repository=AsyncMock())
+        result = await service.search_all(query=None)
+        self.assertEqual(len(result), 1)
+        mock_repo.select_all.assert_awaited()
+
+    async def test_search_count(self):
+        mock_repo = AsyncMock()
+        mock_repo.select_count.return_value = 5
+        service = CustomerServices(customer_repository=mock_repo, tag_repository=AsyncMock())
+        count = await service.search_count(query="a")
+        self.assertEqual(count, 5)
+        mock_repo.select_count.assert_awaited_with(query="a", tags=[])
+
+    async def test_delete_by_id(self):
+        mock_repo = AsyncMock()
+        mock_repo.delete_by_id.return_value = CustomerInDB(
+            id="d", name="Del", organization_id="org1", is_active=True,
+            addresses=[], tags=[], created_at=UTCDateTime.now(), updated_at=UTCDateTime.now()
+        )
+        service = CustomerServices(customer_repository=mock_repo, tag_repository=AsyncMock())
+        result = await service.delete_by_id(id="d")
+        self.assertEqual(result.id, "d")
+        mock_repo.delete_by_id.assert_awaited_with(id="d")
+
+    async def test_search_all_expand_tags(self):
+        from app.crud.tags.schemas import TagInDB
+        mock_repo = AsyncMock()
+        mock_repo.select_all.return_value = [
+            CustomerInDB(
+                id="1", name="A", organization_id="org1", is_active=True,
+                addresses=[], tags=["tag1"],
+                created_at=UTCDateTime.now(), updated_at=UTCDateTime.now()
+            )
+        ]
+        mock_tag_repo = AsyncMock()
+        mock_tag_repo.select_by_id.return_value = TagInDB(id="tag1", name="Tag 1", organization_id="org1")
+        service = CustomerServices(customer_repository=mock_repo, tag_repository=mock_tag_repo)
+        result = await service.search_all(query=None, expand=["tags"])
+        self.assertEqual(result[0].tags[0].name, "Tag 1")
+        mock_tag_repo.select_by_id.assert_awaited_with(id="tag1", raise_404=False)


### PR DESCRIPTION
## Summary
- add tests for customer command/query routers
- cover customer repository and services

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68634d11b3b4832a8fe30a91f261a60d