### PR TITLE
Add product router tests

### DIFF
--- a/tests/api/routers/products/test_products_command_router.py
+++ b/tests/api/routers/products/test_products_command_router.py
@@ -1,0 +1,151 @@
+import unittest
+from bson import ObjectId
+from fastapi.testclient import TestClient
+from mongoengine import connect, disconnect
+import mongomock
+
+from app.api.dependencies.auth import decode_jwt
+from app.api.dependencies.get_current_organization import check_current_organization
+from app.application import app
+from app.core.utils.features import Feature
+from app.core.utils.utc_datetime import UTCDateTime
+from app.crud.plan_features.schemas import PlanFeatureInDB
+from app.crud.products.models import ProductModel
+from tests.payloads import USER_IN_DB
+
+
+class TestProductsCommandRouter(unittest.TestCase):
+    def setUp(self):
+        def override_dependency(mock):
+            def _dependency():
+                return mock
+            return _dependency
+
+        disconnect()
+        connect(mongo_client_class=mongomock.MongoClient)
+
+        self.test_client = TestClient(app)
+
+        app.dependency_overrides[decode_jwt] = override_dependency(USER_IN_DB)
+        app.dependency_overrides[check_current_organization] = override_dependency("org_123")
+
+        self.mock_feature = PlanFeatureInDB(
+            id=str(ObjectId()),
+            additional_price=0,
+            allow_additional=False,
+            display_name="Max products",
+            display_value="1",
+            name=Feature.MAX_PRODUCTS,
+            value="2",
+            plan_id=str(ObjectId()),
+            created_at=UTCDateTime.now(),
+            updated_at=UTCDateTime.now(),
+        )
+
+        app.user_middleware.clear()
+
+    def tearDown(self) -> None:
+        disconnect()
+        app.dependency_overrides = {}
+
+    def insert_mock_product(self, name="Product"):
+        product = ProductModel(
+            name=name,
+            description="desc",
+            organization_id="org_123",
+            unit_price=10.0,
+            unit_cost=5.0,
+            tags=[],
+        )
+        product.save()
+        return str(product.id)
+
+    @unittest.mock.patch("app.crud.products.services.get_plan_feature")
+    def test_post_product_success(self, mock_get_plan_feature):
+        mock_get_plan_feature.return_value = self.mock_feature.model_copy(update={"value": "-"})
+        response = self.test_client.post(
+            url="/api/products",
+            json={
+                "name": "Prod",
+                "description": "desc",
+                "unitPrice": 10.0,
+                "unitCost": 5.0,
+                "tags": []
+            },
+            headers={"organization-id": "org_123"},
+        )
+        json = response.json()
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(json["message"], "Product created with success")
+        self.assertIsNotNone(json["data"]["id"])
+        self.assertEqual(json["data"]["name"], "Prod")
+
+    @unittest.mock.patch("app.crud.products.services.get_plan_feature")
+    def test_post_product_failure_due_to_limit(self, mock_get_plan_feature):
+        mock_get_plan_feature.return_value = self.mock_feature.model_copy()
+        self.insert_mock_product(name="A")
+        self.insert_mock_product(name="B")
+        response = self.test_client.post(
+            url="/api/products",
+            json={
+                "name": "C",
+                "description": "desc",
+                "unitPrice": 10.0,
+                "unitCost": 5.0,
+                "tags": []
+            },
+            headers={"organization-id": "org_123"},
+        )
+        self.assertEqual(response.status_code, 403)
+        self.assertIn("Maximum number of products", response.json()["message"])
+
+    def test_put_product_success(self):
+        prod_id = self.insert_mock_product(name="Old")
+        response = self.test_client.put(
+            f"/api/products/{prod_id}",
+            json={"name": "Updated"},
+            headers={"organization-id": "org_123"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["message"], "Product updated with success")
+
+    def test_put_product_failure(self):
+        response = self.test_client.put(
+            "/api/products/invalid",
+            json={"name": "Fail"},
+            headers={"organization-id": "org_123"},
+        )
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json()["message"], "Product #invalid not found")
+
+    def test_delete_product_success(self):
+        prod_id = self.insert_mock_product(name="Del")
+        response = self.test_client.delete(
+            f"/api/products/{prod_id}", headers={"organization-id": "org_123"}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["message"], "Product deleted with success")
+
+    def test_delete_product_not_found(self):
+        response = self.test_client.delete(
+            "/api/products/9999", headers={"organization-id": "org_123"}
+        )
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json()["message"], "Product #9999 not found")
+
+    def test_post_product_invalid_payload_returns_422(self):
+        response = self.test_client.post(
+            url="/api/products",
+            json={"name": "Only"},
+            headers={"organization-id": "org_123"},
+        )
+        self.assertEqual(response.status_code, 422)
+
+    def test_put_product_invalid_payload_returns_422(self):
+        prod_id = self.insert_mock_product(name="Invalid")
+        response = self.test_client.put(
+            f"/api/products/{prod_id}",
+            json={"unitPrice": "invalid"},
+            headers={"organization-id": "org_123"},
+        )
+        self.assertEqual(response.status_code, 422)

--- a/tests/api/routers/products/test_products_query_router.py
+++ b/tests/api/routers/products/test_products_query_router.py
@@ -1,0 +1,109 @@
+import unittest
+from fastapi.testclient import TestClient
+from mongoengine import connect, disconnect
+import mongomock
+
+from app.api.dependencies.auth import decode_jwt
+from app.api.dependencies.get_current_organization import check_current_organization
+from app.application import app
+from app.crud.products.models import ProductModel
+from app.crud.tags.models import TagModel
+from app.core.utils.utc_datetime import UTCDateTime
+from tests.payloads import USER_IN_DB
+
+
+class TestProductsQueryRouter(unittest.TestCase):
+    def setUp(self):
+        def override_dependency(mock):
+            def _dependency():
+                return mock
+            return _dependency
+
+        disconnect()
+        connect(mongo_client_class=mongomock.MongoClient)
+        self.test_client = TestClient(app)
+
+        app.dependency_overrides[decode_jwt] = override_dependency(USER_IN_DB)
+        app.dependency_overrides[check_current_organization] = override_dependency("org_123")
+        app.user_middleware.clear()
+
+    def tearDown(self) -> None:
+        disconnect()
+        app.dependency_overrides = {}
+
+    def insert_mock_product(self, name="Product"):
+        product = ProductModel(
+            name=name,
+            description="desc",
+            organization_id="org_123",
+            unit_price=10.0,
+            unit_cost=5.0,
+            tags=[],
+        )
+        product.save()
+        return str(product.id)
+
+    def test_get_product_by_id_success(self):
+        prod_id = self.insert_mock_product(name="By ID")
+        response = self.test_client.get(
+            f"/api/products/{prod_id}",
+            headers={"organization-id": "org_123"}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["data"]["name"], "By ID")
+        self.assertEqual(response.json()["message"], "Product found with success")
+
+    def test_get_product_by_id_not_found(self):
+        response = self.test_client.get(
+            "/api/products/000000000000000000000000",
+            headers={"organization-id": "org_123"}
+        )
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json()["message"], "Product #000000000000000000000000 not found")
+
+    def test_get_products_with_results(self):
+        self.insert_mock_product(name="A")
+        self.insert_mock_product(name="B")
+        response = self.test_client.get(
+            "/api/products",
+            headers={"organization-id": "org_123"}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["message"], "Products found with success")
+        self.assertGreaterEqual(len(response.json()["data"]), 2)
+
+    def test_get_products_empty_returns_204(self):
+        response = self.test_client.get(
+            "/api/products",
+            headers={"organization-id": "org_123"}
+        )
+        self.assertEqual(response.status_code, 204)
+
+    def test_get_products_expand_tags(self):
+        tag = TagModel(name="Tag1", organization_id="org_123")
+        tag.save()
+        product = ProductModel(
+            name="With Tag",
+            description="desc",
+            organization_id="org_123",
+            unit_price=1.0,
+            unit_cost=0.5,
+            tags=[tag.id],
+        )
+        product.save()
+        response = self.test_client.get(
+            "/api/products?expand=tags",
+            headers={"organization-id": "org_123"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["data"][0]["tags"][0]["name"], "Tag1")
+
+    def test_get_products_count(self):
+        self.insert_mock_product(name="One")
+        response = self.test_client.get(
+            "/api/products/metrics/count",
+            headers={"organization-id": "org_123"}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["message"], "Products count found with success")
+        self.assertEqual(response.json()["data"], 1)

--- a/tests/crud/products/test_products_repository.py
+++ b/tests/crud/products/test_products_repository.py
@@ -1,0 +1,114 @@
+import unittest
+from mongoengine import connect, disconnect
+import mongomock
+
+from app.core.utils.utc_datetime import UTCDateTime
+from app.crud.products.models import ProductModel
+from app.crud.products.repositories import ProductRepository
+from app.crud.products.schemas import Product
+from app.core.exceptions import NotFoundError, UnprocessableEntity
+
+
+class TestProductRepository(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        connect(
+            "mongoenginetest",
+            host="mongodb://localhost",
+            mongo_client_class=mongomock.MongoClient,
+            alias="default",
+        )
+        self.repo = ProductRepository(organization_id="org1")
+
+    def tearDown(self):
+        disconnect()
+
+    async def _product(self, name="Cake", tags=None):
+        return Product(
+            name=name,
+            description="desc",
+            unit_price=10.0,
+            unit_cost=5.0,
+            tags=tags or [],
+        )
+
+    async def test_create_product(self):
+        prod = await self._product(name="Choco")
+        result = await self.repo.create(prod)
+        self.assertEqual(result.name, "Choco")
+        self.assertEqual(ProductModel.objects.count(), 1)
+
+    async def test_create_product_strips_and_capitalizes_name(self):
+        prod = await self._product(name="  sweet ")
+        result = await self.repo.create(prod)
+        self.assertEqual(result.name, "Sweet")
+
+    async def test_update_product(self):
+        created = await self.repo.create(await self._product(name="Old"))
+        created.name = "New"
+        updated = await self.repo.update(created)
+        self.assertEqual(updated.name, "New")
+
+    async def test_select_by_id_success(self):
+        created = await self.repo.create(await self._product())
+        result = await self.repo.select_by_id(id=created.id)
+        self.assertEqual(result.id, created.id)
+
+    async def test_select_by_id_not_found(self):
+        with self.assertRaises(NotFoundError):
+            await self.repo.select_by_id(id="missing")
+
+    async def test_select_by_id_raise_false_returns_none(self):
+        result = await self.repo.select_by_id(id="missing", raise_404=False)
+        self.assertIsNone(result)
+
+    async def test_select_count_with_query(self):
+        await self.repo.create(await self._product(name="Apple"))
+        await self.repo.create(await self._product(name="Banana"))
+        await self.repo.create(await self._product(name="Apricot"))
+        count = await self.repo.select_count(query="Ap")
+        self.assertEqual(count, 2)
+
+    async def test_select_all_with_pagination(self):
+        await self.repo.create(await self._product(name="A"))
+        await self.repo.create(await self._product(name="B"))
+        await self.repo.create(await self._product(name="C"))
+        results = await self.repo.select_all(query=None, page=1, page_size=2)
+        self.assertEqual(len(results), 2)
+        results_p2 = await self.repo.select_all(query=None, page=2, page_size=2)
+        self.assertEqual(len(results_p2), 1)
+        names = {r.name for r in results + results_p2}
+        self.assertEqual(names, {"A", "B", "C"})
+
+    async def test_select_all_filter_by_tags(self):
+        await self.repo.create(await self._product(name="TaggedA", tags=["t1", "t2"]))
+        await self.repo.create(await self._product(name="TaggedB", tags=["t2"]))
+        results = await self.repo.select_all(query=None, tags=["t1"], page=None, page_size=None)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].name, "Taggeda")
+
+    async def test_delete_by_id_success(self):
+        created = await self.repo.create(await self._product(name="Del"))
+        result = await self.repo.delete_by_id(id=created.id)
+        self.assertEqual(ProductModel.objects(is_active=True).count(), 0)
+        self.assertEqual(result.name, "Del")
+
+    async def test_delete_by_id_not_found(self):
+        with self.assertRaises(NotFoundError):
+            await self.repo.delete_by_id(id="missing")
+
+    async def test_update_nonexistent_product_raises_unprocessable(self):
+        from app.crud.products.schemas import ProductInDB
+        missing = ProductInDB(
+            id="missing",
+            name="Missing",
+            description="D",
+            unit_price=1.0,
+            unit_cost=1.0,
+            tags=[],
+            organization_id="org1",
+            created_at=UTCDateTime.now(),
+            updated_at=UTCDateTime.now(),
+            is_active=True,
+        )
+        with self.assertRaises(UnprocessableEntity):
+            await self.repo.update(missing)

--- a/tests/crud/products/test_products_schemas.py
+++ b/tests/crud/products/test_products_schemas.py
@@ -1,0 +1,47 @@
+import unittest
+from app.crud.products.schemas import (
+    Item,
+    ProductSection,
+    Product,
+    UpdateProduct,
+)
+
+
+class TestProductSchemas(unittest.TestCase):
+    def test_item_auto_generates_id(self):
+        item = Item(name="A", unit_price=1.0, unit_cost=0.5)
+        self.assertIsNotNone(item.id)
+
+    def test_product_section_requires_item(self):
+        with self.assertRaises(ValueError):
+            ProductSection(title="T", min_choices=1, max_choices=1, items=[])
+
+    def test_product_section_auto_id(self):
+        section = ProductSection(title="T", min_choices=1, max_choices=1, items=[Item(name="A", unit_price=1, unit_cost=1)])
+        self.assertIsNotNone(section.id)
+
+    def test_product_validation_price(self):
+        with self.assertRaises(ValueError):
+            Product(name="A", description="d", unit_price=1, unit_cost=2)
+
+    def test_product_validation_unique_tags(self):
+        with self.assertRaises(ValueError):
+            Product(name="A", description="d", unit_price=2, unit_cost=1, tags=["x", "x"])
+
+    def test_product_get_section_by_id(self):
+        section = ProductSection(title="T", min_choices=1, max_choices=1, items=[Item(name="A", unit_price=1, unit_cost=1)])
+        product = Product(name="A", description="d", unit_price=2, unit_cost=1, sections=[section])
+        self.assertEqual(product.get_section_by_id(section.id).title, "T")
+
+    def test_validate_updated_fields(self):
+        product = Product(name="A", description="d", unit_price=2, unit_cost=1)
+        updated = UpdateProduct(name="B")
+        changed = product.validate_updated_fields(updated)
+        self.assertTrue(changed)
+        self.assertEqual(product.name, "B")
+
+    def test_update_product_validation(self):
+        with self.assertRaises(ValueError):
+            UpdateProduct(unit_price=1, unit_cost=2)
+        with self.assertRaises(ValueError):
+            UpdateProduct(tags=["a", "a"])

--- a/tests/crud/products/test_products_services.py
+++ b/tests/crud/products/test_products_services.py
@@ -1,0 +1,146 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from mongoengine import connect, disconnect
+import mongomock
+
+from app.crud.products.repositories import ProductRepository
+from app.crud.products.schemas import Product, ProductInDB, UpdateProduct, ProductSection, Item
+from app.crud.products.services import ProductServices
+from app.crud.tags.repositories import TagRepository
+from app.crud.files.repositories import FileRepository
+from app.crud.files.schemas import FilePurpose
+from app.core.utils.utc_datetime import UTCDateTime
+from app.api.exceptions.authentication_exceptions import UnauthorizedException, BadRequestException
+from app.core.exceptions.users import UnprocessableEntity
+
+
+class TestProductServices(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        connect(
+            "mongoenginetest",
+            host="mongodb://localhost",
+            mongo_client_class=mongomock.MongoClient,
+            alias="default",
+        )
+        repo = ProductRepository(organization_id="org1")
+        self.tag_repo = TagRepository(organization_id="org1")
+        self.file_repo = FileRepository(organization_id="org1")
+        self.service = ProductServices(
+            product_repository=repo,
+            tag_repository=self.tag_repo,
+            file_repository=self.file_repo,
+        )
+
+    def tearDown(self):
+        disconnect()
+
+    async def _product(self, name="Cake"):
+        return Product(
+            name=name,
+            description="desc",
+            unit_price=10.0,
+            unit_cost=5.0,
+            tags=[],
+            sections=[],
+        )
+
+    @patch("app.crud.products.services.get_plan_feature", new_callable=AsyncMock)
+    async def test_create_product_respects_plan_limit(self, mock_plan):
+        mock_plan.return_value = SimpleNamespace(value="2")
+        await self.service.create(await self._product())
+        with self.assertRaises(UnauthorizedException):
+            await self.service.create(await self._product(name="Another"))
+
+    @patch("app.crud.products.services.get_plan_feature", new_callable=AsyncMock)
+    async def test_create_product_success(self, mock_plan):
+        mock_plan.return_value = SimpleNamespace(value="-")
+        result = await self.service.create(await self._product())
+        self.assertEqual(result.name, "Cake")
+
+    @patch("app.crud.products.services.get_plan_feature", new_callable=AsyncMock)
+    async def test_create_product_invalid_file(self, mock_plan):
+        mock_plan.return_value = SimpleNamespace(value="-")
+        prod = await self._product()
+        prod.file_id = "file1"
+        self.file_repo.select_by_id = AsyncMock(return_value=SimpleNamespace(purpose="OTHER"))
+        with self.assertRaises(BadRequestException):
+            await self.service.create(prod)
+
+    @patch("app.crud.products.services.get_plan_feature", new_callable=AsyncMock)
+    async def test_update_product(self, mock_plan):
+        mock_plan.return_value = SimpleNamespace(value="-")
+        created = await self.service.create(await self._product())
+        updated = await self.service.update(id=created.id, updated_product=UpdateProduct(name="New"))
+        self.assertEqual(updated.name, "New")
+
+    async def test_update_without_real_change(self):
+        prod = ProductInDB(
+            id="1",
+            name="Same",
+            description="d",
+            unit_price=1.0,
+            unit_cost=1.0,
+            tags=[],
+            organization_id="org1",
+            created_at=UTCDateTime.now(),
+            updated_at=UTCDateTime.now(),
+            is_active=True,
+        )
+        prod.validate_updated_fields = lambda update_product: False
+        mock_repo = AsyncMock()
+        mock_repo.select_by_id.return_value = prod
+        service = ProductServices(product_repository=mock_repo, tag_repository=AsyncMock(), file_repository=AsyncMock())
+        result = await service.update(id="1", updated_product=UpdateProduct())
+        self.assertEqual(result.name, "Same")
+        mock_repo.update.assert_not_awaited()
+
+    async def test_search_by_id_calls_repo(self):
+        mock_repo = AsyncMock()
+        mock_repo.select_by_id.return_value = "prod"
+        service = ProductServices(product_repository=mock_repo, tag_repository=AsyncMock(), file_repository=AsyncMock())
+        result = await service.search_by_id(id="x")
+        self.assertEqual(result, "prod")
+        mock_repo.select_by_id.assert_awaited_with(id="x")
+
+    async def test_search_all(self):
+        mock_repo = AsyncMock()
+        mock_repo.select_all.return_value = ["prod"]
+        service = ProductServices(product_repository=mock_repo, tag_repository=AsyncMock(), file_repository=AsyncMock())
+        result = await service.search_all(query=None)
+        self.assertEqual(result, ["prod"])
+        mock_repo.select_all.assert_awaited()
+
+    async def test_search_count(self):
+        mock_repo = AsyncMock()
+        mock_repo.select_count.return_value = 3
+        service = ProductServices(product_repository=mock_repo, tag_repository=AsyncMock(), file_repository=AsyncMock())
+        count = await service.search_count(query="a")
+        self.assertEqual(count, 3)
+        mock_repo.select_count.assert_awaited_with(query="a", tags=[])
+
+    async def test_delete_by_id(self):
+        mock_repo = AsyncMock()
+        mock_repo.delete_by_id.return_value = "deleted"
+        service = ProductServices(product_repository=mock_repo, tag_repository=AsyncMock(), file_repository=AsyncMock())
+        result = await service.delete_by_id(id="d")
+        self.assertEqual(result, "deleted")
+        mock_repo.delete_by_id.assert_awaited_with(id="d")
+
+    async def test_validade_additionals_invalid(self):
+        mock_repo = AsyncMock()
+        service = ProductServices(product_repository=mock_repo, tag_repository=AsyncMock(), file_repository=self.file_repo)
+        section = ProductSection(title="Sec", min_choices=0, max_choices=0, items=[Item(name="Item", unit_price=1.0, unit_cost=1.0)])
+        product = Product(name="A", description="d", unit_price=1.0, unit_cost=1.0, sections=[section])
+        with self.assertRaises(UnprocessableEntity):
+            await service.validade_additionals(product)
+
+    async def test_validade_additionals_file_not_found(self):
+        mock_repo = AsyncMock()
+        file_repo = AsyncMock()
+        file_repo.select_by_id.return_value = None
+        service = ProductServices(product_repository=mock_repo, tag_repository=AsyncMock(), file_repository=file_repo)
+        section = ProductSection(title="Sec", min_choices=1, max_choices=1, items=[Item(name="Item", unit_price=1.0, unit_cost=1.0, file_id="x")])
+        product = Product(name="A", description="d", unit_price=1.0, unit_cost=1.0, sections=[section])
+        with self.assertRaises(UnprocessableEntity):
+            await service.validade_additionals(product)


### PR DESCRIPTION
## Summary
- add command router tests for products
- add query router tests for products

## Testing
- `pip install -r requirements/dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863579825f8832a89b317255d3f071c