### PR TITLE
feat: expand additional item file

### DIFF
--- a/app/api/composers/product_additional_composite.py
+++ b/app/api/composers/product_additional_composite.py
@@ -5,6 +5,7 @@ from app.crud.product_additionals.repositories import ProductAdditionalRepositor
 from app.crud.product_additionals.services import ProductAdditionalServices
 from app.crud.products.repositories import ProductRepository
 from app.crud.additional_items.repositories import AdditionalItemRepository
+from app.crud.files.repositories import FileRepository
 
 
 async def product_additional_composer(
@@ -13,9 +14,11 @@ async def product_additional_composer(
     additional_repository = ProductAdditionalRepository(organization_id=organization_id)
     product_repository = ProductRepository(organization_id=organization_id)
     item_repository = AdditionalItemRepository(organization_id=organization_id)
+    file_repository = FileRepository(organization_id=organization_id)
     services = ProductAdditionalServices(
         additional_repository=additional_repository,
         product_repository=product_repository,
         item_repository=item_repository,
+        file_repository=file_repository,
     )
     return services

--- a/app/api/composers/product_composite.py
+++ b/app/api/composers/product_composite.py
@@ -20,6 +20,7 @@ async def product_composer(
         additional_repository=product_additional_repository,
         product_repository=product_repository,
         item_repository=AdditionalItemRepository(organization_id=organization_id),
+        file_repository=file_repository,
     )
     product_services = ProductServices(
         product_repository=product_repository,

--- a/app/crud/additional_items/models.py
+++ b/app/crud/additional_items/models.py
@@ -9,6 +9,7 @@ class AdditionalItemModel(BaseDocument):
     additional_id = StringField(required=True)
     position = IntField(required=True)
     product_id = StringField(required=False)
+    file_id = StringField(required=False, default=None)
     label = StringField(required=True)
     unit_price = FloatField(required=True)
     unit_cost = FloatField(required=True)

--- a/app/crud/additional_items/schemas.py
+++ b/app/crud/additional_items/schemas.py
@@ -3,10 +3,12 @@ from typing import Optional
 from pydantic import Field
 from app.core.models import DatabaseModel
 from app.core.models.base_schema import GenericModel
+from app.crud.files.schemas import FileInDB
 
 class AdditionalItem(GenericModel):
     position: int = Field(example=1)
     product_id: str | None = Field(default=None, example="prod_123")
+    file_id: str | None = Field(default=None, example="file_123")
     label: str = Field(example="Extra")
     unit_price: float = Field(example=0.0)
     unit_cost: float = Field(example=0.0)
@@ -21,6 +23,10 @@ class AdditionalItem(GenericModel):
 
         if update.product_id is not None:
             self.product_id = update.product_id
+            is_updated = True
+
+        if update.file_id is not None:
+            self.file_id = update.file_id
             is_updated = True
 
         if update.label is not None:
@@ -45,6 +51,7 @@ class AdditionalItem(GenericModel):
 class UpdateAdditionalItem(GenericModel):
     position: Optional[int] = Field(default=None, example=1)
     product_id: Optional[str] = Field(default=None, example="prod_123")
+    file_id: Optional[str] = Field(default=None, example="file_123")
     label: Optional[str] = Field(default=None, example="Extra")
     unit_price: Optional[float] = Field(default=None, example=0.0)
     unit_cost: Optional[float] = Field(default=None, example=0.0)
@@ -54,3 +61,7 @@ class UpdateAdditionalItem(GenericModel):
 class AdditionalItemInDB(AdditionalItem, DatabaseModel):
     organization_id: str = Field(example="org_123")
     additional_id: str = Field(example="add_123")
+
+
+class CompleteAdditionalItem(AdditionalItemInDB):
+    file: FileInDB | None = Field(default=None)

--- a/app/crud/product_additionals/schemas.py
+++ b/app/crud/product_additionals/schemas.py
@@ -6,7 +6,7 @@ from pydantic import Field
 from app.core.models import DatabaseModel
 from app.core.models.base_schema import GenericModel
 from app.crud.additional_items import AdditionalItem
-from app.crud.additional_items.schemas import AdditionalItemInDB
+from app.crud.additional_items.schemas import AdditionalItemInDB, CompleteAdditionalItem
 
 
 class OptionKind(str, Enum):
@@ -74,7 +74,7 @@ class UpdateProductAdditional(GenericModel):
 class ProductAdditionalInDB(ProductAdditional, DatabaseModel):
     organization_id: str = Field(example="org_123")
     product_id: str = Field(example="prod_123")
-    items: List[AdditionalItemInDB] = Field(default=[], example=[
+    items: List[AdditionalItemInDB | CompleteAdditionalItem] = Field(default=[], example=[
         {
             "position": 1,
             "product_id": "prod_123",


### PR DESCRIPTION
## Summary
- ensure additional item queries always hydrate `file` and remove `expand` parameters from routes
- simplify product additional services to always fetch file data for items
- adjust product services and tests to reflect automatic file inclusion

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68916971fbf8832a8c7b65ef185e1ec1