### PR TITLE
feat: allow products in section offers

### DIFF
--- a/app/api/composers/section_offer_composite.py
+++ b/app/api/composers/section_offer_composite.py
@@ -3,6 +3,7 @@ from fastapi import Depends
 from app.api.dependencies.get_current_organization import check_current_organization
 from app.crud.sections.repositories import SectionRepository
 from app.crud.offers.repositories import OfferRepository
+from app.crud.products.repositories import ProductRepository
 from app.crud.section_offers.repositories import SectionOfferRepository
 from app.crud.section_offers.services import SectionOfferServices
 
@@ -13,10 +14,12 @@ async def section_offer_composer(
     section_offer_repository = SectionOfferRepository(organization_id=organization_id)
     section_repository = SectionRepository(organization_id=organization_id)
     offer_repository = OfferRepository(organization_id=organization_id)
+    product_repository = ProductRepository(organization_id=organization_id)
 
     services = SectionOfferServices(
         section_offer_repository=section_offer_repository,
         section_repository=section_repository,
         offer_repository=offer_repository,
+        product_repository=product_repository,
     )
     return services

--- a/app/crud/section_offers/models.py
+++ b/app/crud/section_offers/models.py
@@ -7,7 +7,8 @@ from app.core.utils.utc_datetime import UTCDateTime
 class SectionOfferModel(BaseDocument):
     organization_id = StringField(required=True)
     section_id = StringField(required=True)
-    offer_id = StringField(required=True)
+    offer_id = StringField(required=False)
+    product_id = StringField(required=False)
     position = IntField(required=True)
     is_visible = BooleanField(default=True)
 

--- a/app/crud/section_offers/repositories.py
+++ b/app/crud/section_offers/repositories.py
@@ -112,3 +112,17 @@ class SectionOfferRepository(Repository):
 
         except Exception as error:
             _logger.error(f"Error on delete_by_offer_id: {error}")
+
+    async def delete_by_product_id(self, product_id: str) -> None:
+        try:
+            objects = SectionOfferModel.objects(
+                product_id=product_id,
+                is_active=True,
+                organization_id=self.organization_id,
+            )
+
+            for model in objects:
+                model.delete()
+
+        except Exception as error:
+            _logger.error(f"Error on delete_by_product_id: {error}")

--- a/app/crud/section_offers/schemas.py
+++ b/app/crud/section_offers/schemas.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 from app.crud.offers.schemas import OfferInDB
+from app.crud.products.schemas import ProductInDB
 
 from pydantic import Field
 
@@ -10,7 +11,8 @@ from app.core.models.base_schema import GenericModel
 
 class SectionOffer(GenericModel):
     section_id: str = Field(example="sec_123")
-    offer_id: str = Field(example="off_123")
+    offer_id: Optional[str] = Field(default=None, example="off_123")
+    product_id: Optional[str] = Field(default=None, example="prod_123")
     position: int = Field(example=1)
     is_visible: bool = Field(default=True, example=True)
 
@@ -39,3 +41,4 @@ class SectionOfferInDB(SectionOffer, DatabaseModel):
 
 class CompleteSectionOffer(SectionOfferInDB):
     offer: OfferInDB | None = Field(default=None)
+    product: ProductInDB | None = Field(default=None)

--- a/tests/api/routers/section_offers/test_section_offers_command_router.py
+++ b/tests/api/routers/section_offers/test_section_offers_command_router.py
@@ -7,6 +7,7 @@ from app.api.dependencies.auth import decode_jwt
 from app.api.dependencies.get_current_organization import check_current_organization
 from app.application import app
 from app.crud.offers.models import OfferModel
+from app.crud.products.models import ProductModel
 from app.crud.sections.models import SectionModel
 from app.crud.menus.models import MenuModel
 from tests.payloads import USER_IN_DB
@@ -57,6 +58,19 @@ class TestSectionOffersCommandRouter(unittest.TestCase):
         offer.save()
         return str(offer.id)
 
+    def insert_mock_product(self, name="Product"):
+        product = ProductModel(
+            name=name,
+            description="d",
+            organization_id="org_123",
+            unit_cost=1.0,
+            unit_price=2.0,
+            tags=[],
+            kind="REGULAR",
+        )
+        product.save()
+        return str(product.id)
+
     def create_section_offer(self):
         section_id = self.insert_mock_section()
         offer_id = self.insert_mock_offer()
@@ -80,6 +94,24 @@ class TestSectionOffersCommandRouter(unittest.TestCase):
             json={
                 "sectionId": section_id,
                 "offerId": offer_id,
+                "position": 1,
+                "isVisible": True,
+            },
+            headers={"organization-id": "org_123"},
+        )
+        json = response.json()
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(json["message"], "Section offer created with success")
+        self.assertIsNotNone(json["data"]["id"])
+
+    def test_post_section_offer_with_product_success(self):
+        section_id = self.insert_mock_section()
+        product_id = self.insert_mock_product()
+        response = self.test_client.post(
+            "/api/section_offers",
+            json={
+                "sectionId": section_id,
+                "productId": product_id,
                 "position": 1,
                 "isVisible": True,
             },

--- a/tests/crud/section_offers/test_section_offers_repository.py
+++ b/tests/crud/section_offers/test_section_offers_repository.py
@@ -21,13 +21,21 @@ class TestSectionOfferRepository(unittest.IsolatedAsyncioTestCase):
     def tearDown(self):
         disconnect()
 
-    async def _section_offer(self, position=1, is_visible=True):
+    async def _section_offer(self, position=1, is_visible=True, product=False):
+        if product:
+            return SectionOffer(section_id="sec1", product_id="prod1", position=position, is_visible=is_visible)
         return SectionOffer(section_id="sec1", offer_id="off1", position=position, is_visible=is_visible)
 
     async def test_create_section_offer(self):
         so = await self._section_offer()
         result = await self.repo.create(so)
         self.assertEqual(result.position, 1)
+        self.assertEqual(SectionOfferModel.objects.count(), 1)
+
+    async def test_create_section_offer_with_product(self):
+        so = await self._section_offer(product=True)
+        result = await self.repo.create(so)
+        self.assertEqual(result.product_id, "prod1")
         self.assertEqual(SectionOfferModel.objects.count(), 1)
 
     async def test_update_section_offer(self):


### PR DESCRIPTION
## Summary
- allow linking products to sections alongside offers
- expose product details when expanding section offers
- cover product-related section offers with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894251c8dec832aabb81e2dbdecad5e