### PR TITLE
Add offer file purpose and tests

### DIFF
--- a/app/api/routers/section_items/query_routers.py
+++ b/app/api/routers/section_items/query_routers.py
@@ -15,6 +15,7 @@ router = APIRouter(tags=["Section Items"])
 @router.get(
     "/sections/{section_id}/items",
     responses={200: {"model": List[SectionItemInDB]}},
+    tags=["Sections"]
 )
 async def get_section_items(
     section_id: str,

--- a/app/crud/files/schemas.py
+++ b/app/crud/files/schemas.py
@@ -8,6 +8,7 @@ from app.core.models.base_schema import GenericModel
 class FilePurpose(str, Enum):
     PRODUCT = "PRODUCTS"
     ORGANIZATION = "ORGANIZATIONS"
+    OFFER = "OFFERS"
 
 
 class File(GenericModel):

--- a/app/crud/files/services.py
+++ b/app/crud/files/services.py
@@ -30,6 +30,9 @@ class FileServices:
         elif purpose == FilePurpose.ORGANIZATION:
             validated_file = await self.validate_image(file=file, size=(640, 480))
 
+        elif purpose == FilePurpose.OFFER:
+            validated_file = await self.validate_image(file=file, size=(640, 480))
+
         else:
             raise BadRequestException(detail="Purpose not recognized")
 

--- a/app/crud/offers/services.py
+++ b/app/crud/offers/services.py
@@ -1,6 +1,8 @@
 from typing import List
 
+from app.api.exceptions.authentication_exceptions import BadRequestException
 from app.crud.files.repositories import FileRepository
+from app.crud.files.schemas import FilePurpose
 from app.crud.products.repositories import ProductRepository
 from app.crud.products.schemas import ProductInDB
 from app.crud.section_items.repositories import SectionItemRepository
@@ -39,7 +41,9 @@ class OfferServices:
         )
 
         if request_offer.file_id is not None:
-            await self.__file_repository.select_by_id(id=request_offer.file_id)
+            file_in_db = await self.__file_repository.select_by_id(id=request_offer.file_id)
+            if file_in_db.purpose != FilePurpose.OFFER:
+                raise BadRequestException(detail="Invalid image for the offer")
 
         offer = Offer(
             name=request_offer.name,
@@ -84,7 +88,9 @@ class OfferServices:
                 offer_in_db.unit_price = product_price
 
             if updated_offer.file_id is not None:
-                await self.__file_repository.select_by_id(id=updated_offer.file_id)
+                file_in_db = await self.__file_repository.select_by_id(id=updated_offer.file_id)
+                if file_in_db.purpose != FilePurpose.OFFER:
+                    raise BadRequestException(detail="Invalid image for the offer")
                 offer_in_db.file_id = updated_offer.file_id
 
             offer_in_db = await self.__offer_repository.update(offer=offer_in_db)


### PR DESCRIPTION
## Summary
- allow files to be tagged for offers with new `OFFER` purpose
- validate file purpose on offer creation and update
- test offer services with valid and invalid file purposes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68953c25ed28832aa4e3cf6cb9c34b39