### PR TITLE
Add organization website, social links and color styling

### DIFF
--- a/app/api/routers/organizations/schemas.py
+++ b/app/api/routers/organizations/schemas.py
@@ -21,6 +21,18 @@ EXAMPLE_ORGANIZATION = {
     "file_id": "fil_123",
     "unit_distance": "KM",
     "tax": 10,
+    "website": "https://sweetcorp.com",
+    "social_links": {
+        "tiktok": "https://tiktok.com/@sweetcorp",
+        "instagram": "https://instagram.com/sweetcorp",
+        "x": "https://x.com/sweetcorp",
+        "facebook": "https://facebook.com/sweetcorp",
+        "google_profile": "https://g.page/sweetcorp",
+    },
+    "styling": {
+        "primary_color": "#111111",
+        "secondary_color": "#222222",
+    },
     "created_at": "2024-01-01T00:00:00Z",
     "updated_at": "2024-01-01T00:00:00Z",
 }

--- a/app/api/routers/tags/schemas.py
+++ b/app/api/routers/tags/schemas.py
@@ -9,7 +9,6 @@ EXAMPLE_TAG = {
     "id": "tag_123",
     "name": "Street Mode",
     "styling": {
-        "font_color": "#000000",
         "primary_color": "#000000",
         "secondary_color": "#111111",
     },

--- a/app/crud/organizations/models.py
+++ b/app/crud/organizations/models.py
@@ -18,6 +18,9 @@ class OrganizationModel(BaseDocument):
     file_id = StringField(required=False, default=None)
     unit_distance = StringField(required=False, default=None)
     tax = FloatField(required=False, default=0)
+    website = StringField(required=False, default=None)
+    social_links = DictField(required=False, default=None)
+    styling = DictField(required=False, default=None)
 
     meta = {"collection": "organizations"}
 

--- a/app/crud/organizations/schemas.py
+++ b/app/crud/organizations/schemas.py
@@ -14,6 +14,7 @@ from app.crud.shared_schemas.distance import UnitDistance
 from app.crud.shared_schemas.language import Language
 from app.crud.shared_schemas.roles import RoleEnum
 from app.crud.shared_schemas.user_organization import UserOrganization
+from app.crud.shared_schemas.styling import Styling
 from app.crud.users.schemas import UserInDB
 
 EMAIL_REGEX = r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$'
@@ -23,6 +24,14 @@ class CompleteUserOrganization(GenericModel):
     user: UserInDB | None = Field(default=None)
     user_id: str = Field(example="user_123", exclude=True)
     role: RoleEnum = Field(example=RoleEnum.ADMIN.value)
+
+
+class SocialLinks(GenericModel):
+    tiktok: str | None = Field(default=None, example="https://tiktok.com/@your_company")
+    instagram: str | None = Field(default=None, example="https://instagram.com/your_company")
+    x: str | None = Field(default=None, example="https://x.com/your_company")
+    facebook: str | None = Field(default=None, example="https://facebook.com/your_company")
+    google_profile: str | None = Field(default=None, example="https://g.page/your_company")
 
 
 class Organization(GenericModel):
@@ -38,6 +47,9 @@ class Organization(GenericModel):
     file_id: str | None = Field(default=None, example="file_123")
     unit_distance: UnitDistance | None = Field(default=None, example=UnitDistance.KM)
     tax: float | None = Field(default=0, example=10)
+    website: str | None = Field(default=None, example="https://your_company.com")
+    social_links: SocialLinks | None = Field(default=None)
+    styling: Styling | None = Field(default=None)
 
     @model_validator(mode="after")
     def validate_model(self) -> "Organization":
@@ -127,6 +139,18 @@ class Organization(GenericModel):
             self.tax = update_organization.tax
             is_updated = True
 
+        if update_organization.website is not None:
+            self.website = update_organization.website
+            is_updated = True
+
+        if update_organization.social_links is not None:
+            self.social_links = update_organization.social_links
+            is_updated = True
+
+        if update_organization.styling is not None:
+            self.styling = update_organization.styling
+            is_updated = True
+
         return is_updated
 
 
@@ -143,6 +167,9 @@ class UpdateOrganization(GenericModel):
     currency: Optional[Currency] = Field(default=None)
     unit_distance: Optional[UnitDistance] = Field(default=None)
     tax: Optional[float] = Field(default=None)
+    website: Optional[str] = Field(default=None)
+    social_links: Optional[SocialLinks] = Field(default=None)
+    styling: Optional[Styling] = Field(default=None)
 
     @model_validator(mode="after")
     def validate_model(self) -> "UpdateOrganization":
@@ -192,6 +219,12 @@ class OrganizationInDB(Organization, DatabaseModel):
 
         if self.users is None:
             self.users = []
+
+        if isinstance(self.social_links, dict):
+            self.social_links = SocialLinks(**self.social_links)
+
+        if isinstance(self.styling, dict):
+            self.styling = Styling(**self.styling)
 
         return self
 

--- a/app/crud/shared_schemas/styling.py
+++ b/app/crud/shared_schemas/styling.py
@@ -1,0 +1,7 @@
+from app.core.models.base_schema import GenericModel
+from pydantic import Field
+
+
+class Styling(GenericModel):
+    primary_color: str | None = Field(default=None, example="#000000")
+    secondary_color: str | None = Field(default=None, example="#111111")

--- a/app/crud/tags/repositories.py
+++ b/app/crud/tags/repositories.py
@@ -8,7 +8,8 @@ from app.core.repositories.base_repository import Repository
 from app.core.utils.utc_datetime import UTCDateTime
 
 from .models import TagModel
-from .schemas import Styling, Tag, TagInDB
+from .schemas import Tag, TagInDB
+from app.crud.shared_schemas.styling import Styling
 
 _logger = get_logger(__name__)
 

--- a/app/crud/tags/schemas.py
+++ b/app/crud/tags/schemas.py
@@ -1,14 +1,11 @@
 from typing import Optional
 
+from typing import Optional
+
 from bson import ObjectId
 from pydantic import ConfigDict, Field, field_validator
 from app.core.models.base_schema import GenericModel
-
-
-class Styling(GenericModel):
-    font_color: str = Field(example="#000000")
-    primary_color: str = Field(example="#000000")
-    secondary_color: str = Field(example="#111111")
+from app.crud.shared_schemas.styling import Styling
 
 
 class Tag(GenericModel):

--- a/tests/api/routers/tags/test_tags_command_router.py
+++ b/tests/api/routers/tags/test_tags_command_router.py
@@ -59,7 +59,6 @@ class TestTagsCommandRouter(unittest.TestCase):
             organization_id="org_123",
             is_active=True,
             styling={
-                "font_color": "#000000",
                 "primary_color": "#111111",
                 "secondary_color": "#222222",
             },

--- a/tests/api/routers/tags/test_tags_query_router.py
+++ b/tests/api/routers/tags/test_tags_query_router.py
@@ -36,7 +36,6 @@ class TestTagsQueryRouter(unittest.TestCase):
             organization_id="org_123",
             is_active=True,
             styling={
-                "font_color": "#000000",
                 "primary_color": "#111111",
                 "secondary_color": "#222222"
             }


### PR DESCRIPTION
## Summary
- add website, social links and styling fields to organizations
- expose shared Styling schema and update tag modules
- remove unused font color from styling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c0d451a00832ab931f23e04926c03