### PR TITLE
fix: batch file lookup to avoid n+1

### DIFF
--- a/app/crud/files/repositories.py
+++ b/app/crud/files/repositories.py
@@ -51,6 +51,26 @@ class FileRepository(Repository):
                 _logger.error(f"Error on select_by_id: {str(error)}")
                 raise NotFoundError(message=f"File #{id} not found")
 
+    async def select_by_ids(self, ids: list[str]) -> dict[str, FileInDB]:
+        try:
+            files = {}
+
+            if not ids:
+                return files
+
+            objects = FileModel.objects(
+                id__in=ids, is_active=True, organization_id=self.organization_id
+            )
+
+            for file_model in objects:
+                files[str(file_model.id)] = FileInDB.model_validate(file_model)
+
+            return files
+
+        except Exception as error:
+            _logger.error(f"Error on select_by_ids: {str(error)}")
+            return {}
+
     async def delete_by_id(self, id: str, raise_404: bool = True) -> FileInDB:
         try:
             file_model: FileModel = FileModel.objects(

--- a/tests/crud/product_additionals/test_product_additionals_services.py
+++ b/tests/crud/product_additionals/test_product_additionals_services.py
@@ -13,6 +13,7 @@ from app.crud.product_additionals.schemas import (
 from app.crud.product_additionals.services import ProductAdditionalServices
 from app.crud.additional_items.repositories import AdditionalItemRepository
 from app.core.utils.utc_datetime import UTCDateTime
+from unittest.mock import AsyncMock
 
 
 class TestProductAdditionalServices(unittest.IsolatedAsyncioTestCase):
@@ -132,9 +133,9 @@ class TestProductAdditionalServices(unittest.IsolatedAsyncioTestCase):
     async def test_search_by_product_id_includes_file(self):
         self.product_repo.select_by_id.return_value = "prod"
         await self.service.create(await self._group(with_item=True), product_id="prod1")
-        self.file_repo.select_by_id.return_value = "file"
+        self.file_repo.select_by_ids.return_value = {"f1": "file"}
         result = await self.service.search_by_product_id("prod1")
-        self.file_repo.select_by_id.assert_awaited_with(id="f1", raise_404=False)
+        self.file_repo.select_by_ids.assert_awaited_once_with(["f1"])
         self.assertEqual(result[0].items[0].file, "file")
 
     async def test_delete_by_product_id(self):


### PR DESCRIPTION
## Summary
- batch file queries to avoid n+1 when expanding offers, products and additionals
- cover file expansion with unit tests

## Testing
- `pytest tests/crud/offers/test_offers_services.py -k test_search_all_with_files_uses_batch -q`
- `pytest tests/crud/products/test_products_services.py -k test_search_all_expand_file_uses_batch -q`
- `pytest tests/crud/product_additionals/test_product_additionals_services.py -k test_search_by_product_id_includes_file -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2143843d8832aa1859b562b83e022