### PR TITLE
Add script to clean unused Tigris images

### DIFF
--- a/scripts/cleanup_tigris_images.py
+++ b/scripts/cleanup_tigris_images.py
@@ -1,0 +1,62 @@
+from urllib.parse import urlparse
+
+import boto3
+from mongoengine import connect
+
+from app.core.configs import get_environment
+from app.crud.files.models import FileModel
+from app.crud.files.schemas import FilePurpose
+
+
+def get_s3_client():
+    env = get_environment()
+    return boto3.client(
+        "s3",
+        endpoint_url=env.BUCKET_BASE_URL,
+        aws_access_key_id=env.BUCKET_ACCESS_KEY_ID,
+        aws_secret_access_key=env.BUCKET_SECRET_KEY,
+    )
+
+
+def collect_referenced_files() -> set[str]:
+    """Retorna o conjunto de chaves do bucket referenciadas na coleção 'files'."""
+    purposes = [FilePurpose.PRODUCT.value, FilePurpose.OFFER.value]
+    referenced: set[str] = set()
+
+    for file in FileModel.objects(purpose__in=purposes):
+        parsed = urlparse(file.url)
+        referenced.add(parsed.path.lstrip("/"))
+
+    return referenced
+
+
+def main() -> None:
+    """Lista e remove arquivos órfãos de imagens no bucket Tigris."""
+    env = get_environment()
+    connect(host=env.DATABASE_HOST)
+    s3_client = get_s3_client()
+
+    bucket_name = env.PRIVATE_BUCKET_NAME
+    paginator = s3_client.get_paginator("list_objects_v2")
+    stored_files = []
+    for page in paginator.paginate(Bucket=bucket_name, Prefix="organization/"):
+        for obj in page.get("Contents", []):
+            stored_files.append(obj["Key"])
+
+    referenced_files = collect_referenced_files()
+    image_extensions = (".png", ".jpg", ".jpeg", ".gif", ".bmp", ".webp")
+
+    orphan_files = [
+        key for key in stored_files
+        if key.lower().endswith(image_extensions) and key not in referenced_files
+    ]
+
+    for key in orphan_files:
+        s3_client.delete_object(Bucket=bucket_name, Key=key)
+        print(f"Deleted: {key}")
+
+    print(f"Total orphan files removed: {len(orphan_files)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/scripts/test_cleanup_tigris_images.py
+++ b/tests/scripts/test_cleanup_tigris_images.py
@@ -1,0 +1,82 @@
+from types import SimpleNamespace
+
+import pytest
+
+from scripts import cleanup_tigris_images
+
+
+def test_collect_referenced_files(monkeypatch):
+    class FakeFile:
+        def __init__(self, url):
+            self.url = url
+
+    fake_files = [
+        FakeFile("https://cdn.local/organization/file1.png"),
+        FakeFile("https://cdn.local/organization/file2.jpg"),
+    ]
+
+    monkeypatch.setattr(
+        cleanup_tigris_images,
+        "FileModel",
+        SimpleNamespace(objects=lambda **kwargs: fake_files),
+    )
+
+    referenced = cleanup_tigris_images.collect_referenced_files()
+
+    assert referenced == {
+        "organization/file1.png",
+        "organization/file2.jpg",
+    }
+
+
+def test_main_deletes_orphan_files(monkeypatch, capsys):
+    class FakePaginator:
+        def paginate(self, Bucket, Prefix):
+            assert Bucket == "bucket"
+            assert Prefix == "organization/"
+            yield {
+                "Contents": [
+                    {"Key": "organization/file1.png"},
+                    {"Key": "organization/file2.jpg"},
+                    {"Key": "organization/file3.txt"},
+                ]
+            }
+
+    class FakeS3Client:
+        def __init__(self):
+            self.deleted = []
+
+        def get_paginator(self, name):
+            assert name == "list_objects_v2"
+            return FakePaginator()
+
+        def delete_object(self, Bucket, Key):
+            self.deleted.append((Bucket, Key))
+
+    fake_client = FakeS3Client()
+
+    monkeypatch.setattr(cleanup_tigris_images, "get_s3_client", lambda: fake_client)
+    monkeypatch.setattr(
+        cleanup_tigris_images,
+        "collect_referenced_files",
+        lambda: {"organization/file1.png"},
+    )
+    monkeypatch.setattr(
+        cleanup_tigris_images,
+        "get_environment",
+        lambda: SimpleNamespace(
+            BUCKET_BASE_URL="http://bucket",
+            BUCKET_ACCESS_KEY_ID="id",
+            BUCKET_SECRET_KEY="secret",
+            PRIVATE_BUCKET_NAME="bucket",
+            DATABASE_HOST="mongodb://localhost/test",
+        ),
+    )
+    monkeypatch.setattr(cleanup_tigris_images, "connect", lambda host: None)
+
+    cleanup_tigris_images.main()
+
+    assert fake_client.deleted == [("bucket", "organization/file2.jpg")]
+    captured = capsys.readouterr()
+    assert "Deleted: organization/file2.jpg" in captured.out
+    assert "Total orphan files removed: 1" in captured.out


### PR DESCRIPTION
## Summary
- add cleanup script to list Tigris images and remove ones not referenced by the `files` collection
- query all file references regardless of active status
- add unit tests verifying image reference gathering and orphan deletion

## Testing
- `pip install -r requirements/dev.txt`
- `pytest`
- `pytest tests/scripts/test_cleanup_tigris_images.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b12d0bc744832aa5a01e0d877dfc53