### PR TITLE
Return 200 with empty list when section has no items

### DIFF
--- a/app/api/dependencies/response.py
+++ b/app/api/dependencies/response.py
@@ -9,13 +9,15 @@ from app.api.shared_schemas.responses import ListResponseSchema, MessageResponse
 
 
 def build_response(
-    status_code: status, message: str, data: BaseModel | List[BaseModel] = None
+    status_code: status,
+    message: str,
+    data: BaseModel | List[BaseModel] | int | None = None,
 ) -> JSONResponse:
     if isinstance(data, int):
         raw_response = Response(message=message, data=None)
         raw_response.data = data
 
-    elif data:
+    elif data is not None:
         raw_response = Response(message=message, data=data)
 
     else:

--- a/app/api/routers/section_items/query_routers.py
+++ b/app/api/routers/section_items/query_routers.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from fastapi import APIRouter, Depends, Query, Security, Response
+from fastapi import APIRouter, Depends, Query, Security
 
 from app.api.composers import section_item_composer
 from app.api.dependencies.response import build_response
@@ -14,10 +14,7 @@ router = APIRouter(tags=["Section Items"])
 
 @router.get(
     "/sections/{section_id}/items",
-    responses={
-        200: {"model": GetSectionItemsResponse},
-        204: {"description": "No Content"},
-    },
+    responses={200: {"model": GetSectionItemsResponse}},
     tags=["Sections"]
 )
 async def get_section_items(
@@ -31,12 +28,8 @@ async def get_section_items(
         section_id=section_id, is_visible=is_visible, expand=expand
     )
 
-    if section_items:
-        return build_response(
-            status_code=200,
-            message="Section items found with success",
-            data=section_items,
-        )
-
-    else:
-        return Response(status_code=204)
+    return build_response(
+        status_code=200,
+        message="Section items found with success",
+        data=section_items,
+    )

--- a/tests/api/routers/section_items/test_section_items_query_router.py
+++ b/tests/api/routers/section_items/test_section_items_query_router.py
@@ -52,13 +52,15 @@ class TestSectionItemsQueryRouter(unittest.TestCase):
         self.assertEqual(len(response.json()["data"]), 1)
         self.mock_service.search_all.assert_awaited_with(section_id="sec1", is_visible=None, expand=[])
 
-    def test_get_section_items_empty_returns_204(self):
+    def test_get_section_items_empty_returns_200_with_empty_list(self):
         self.mock_service.search_all.return_value = []
         response = self.test_client.get(
             "/api/sections/sec1/items",
             headers={"organization-id": "org_123"},
         )
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["data"], [])
+        self.assertEqual(response.json()["message"], "Section items found with success")
 
     def test_get_section_items_expand_items_offer(self):
         so = self._section_item_in_db()


### PR DESCRIPTION
## Summary
- ensure API for section items returns 200 with an empty array instead of 204 when no items
- allow response helper to include empty lists in the data field
- adjust tests for the new behavior

## Testing
- `pytest tests/api/routers/section_items/test_section_items_query_router.py::TestSectionItemsQueryRouter::test_get_section_items_empty_returns_200_with_empty_list -q --disable-warnings`


------
https://chatgpt.com/codex/tasks/task_e_68b751296c80832a9151bdf4180e6522