### PR TITLE
Add accept and reject endpoints for pre-orders

### DIFF
--- a/app/api/routers/pre_orders/command_routers.py
+++ b/app/api/routers/pre_orders/command_routers.py
@@ -1,14 +1,16 @@
 from typing import List
 from fastapi import APIRouter, Depends, Query, Security
 
-from app.api.composers import pre_order_composer
+from app.api.composers import pre_order_composer, order_composer
 from app.api.dependencies import build_response, decode_jwt
 from app.api.shared_schemas.responses import MessageResponse
 from app.crud.users import UserInDB
 from app.crud.pre_orders import PreOrderServices, UpdatePreOrder
+from app.crud.orders import OrderServices
 from .schemas import (
     UpdatePreOrderResponse,
     DeletePreOrderResponse,
+    AcceptPreOrderResponse,
 )
 
 router = APIRouter(tags=["Pre-Orders"])
@@ -36,6 +38,57 @@ async def update_pre_orders(
             status_code=200, message="Pré pedido atualizado com sucesso", data=pre_order_in_db
         )
 
+    else:
+        return build_response(
+            status_code=404, message=f"Pré pedido {pre_order_id} não encontrado", data=None
+        )
+
+
+@router.post(
+    "/pre_orders/{pre_order_id}/reject",
+    responses={200: {"model": UpdatePreOrderResponse}, 404: {"model": MessageResponse}},
+)
+async def reject_pre_order(
+    pre_order_id: str,
+    current_user: UserInDB = Security(decode_jwt, scopes=["pre-order:create"]),
+    pre_order_services: PreOrderServices = Depends(pre_order_composer),
+):
+    pre_order_in_db = await pre_order_services.reject_pre_order(
+        pre_order_id=pre_order_id,
+    )
+
+    if pre_order_in_db:
+        return build_response(
+            status_code=200, message="Pré pedido rejeitado com sucesso", data=pre_order_in_db
+        )
+
+    else:
+        return build_response(
+            status_code=404, message=f"Pré pedido {pre_order_id} não encontrado", data=None
+        )
+
+
+@router.post(
+    "/pre_orders/{pre_order_id}/accept",
+    responses={201: {"model": AcceptPreOrderResponse}, 404: {"model": MessageResponse}},
+)
+async def accept_pre_order(
+    pre_order_id: str,
+    current_user: UserInDB = Security(decode_jwt, scopes=["pre-order:create"]),
+    pre_order_services: PreOrderServices = Depends(pre_order_composer),
+    order_services: OrderServices = Depends(order_composer),
+):
+    order_in_db = await pre_order_services.accept_pre_order(
+        pre_order_id=pre_order_id,
+        order_services=order_services,
+    )
+
+    if order_in_db:
+        return build_response(
+            status_code=201,
+            message="Pré pedido aceito com sucesso",
+            data=order_in_db,
+        )
     else:
         return build_response(
             status_code=404, message=f"Pré pedido {pre_order_id} não encontrado", data=None

--- a/app/api/routers/pre_orders/schemas.py
+++ b/app/api/routers/pre_orders/schemas.py
@@ -2,6 +2,7 @@ from typing import List
 from pydantic import Field, ConfigDict
 from app.api.shared_schemas.responses import Response, ListResponseSchema
 from app.crud.pre_orders.schemas import PreOrderInDB
+from app.crud.orders.schemas import OrderInDB
 EXAMPLE_PRE_ORDER = {
     "id": "pre_123",
     "code": "45623",
@@ -72,3 +73,15 @@ class UpdatePreOrderResponse(Response):
 class DeletePreOrderResponse(Response):
     data: PreOrderInDB | None = Field()
     model_config = ConfigDict(json_schema_extra={"example": {"message": "Pré pedido deletado com sucesso", "data": EXAMPLE_PRE_ORDER}})
+
+
+class AcceptPreOrderResponse(Response):
+    data: OrderInDB | None = Field()
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "message": "Pré pedido aceito com sucesso",
+                "data": {},
+            }
+        }
+    )


### PR DESCRIPTION
## Summary
- add endpoints to accept or reject pre-orders
- convert accepted pre-orders into orders and notify customers
- cover pre-order acceptance and rejection with tests
- drop unused `expand` argument from pre-order rejection service

## Testing
- `PYTHONWARNINGS=ignore pytest tests/crud/pre_orders/test_pre_orders_services.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68be57ad03c4832a85db89318c2334ff