### PR TITLE
Store accepted order IDs on pre-orders

### DIFF
--- a/app/crud/pre_orders/models.py
+++ b/app/crud/pre_orders/models.py
@@ -16,6 +16,7 @@ class PreOrderModel(BaseDocument):
     status = StringField(default=None, required=False)
     items = ListField(DictField(), default=[])
     tax = FloatField(default=0, required=False)
+    order_id = StringField(required=False)
 
     meta = {
         "collection": "pre_orders"

--- a/app/crud/pre_orders/repositories.py
+++ b/app/crud/pre_orders/repositories.py
@@ -16,7 +16,7 @@ class PreOrderRepository(Repository):
         super().__init__()
         self.organization_id = organization_id
 
-    async def update_status(self, pre_order_id: str, new_status: PreOrderStatus) -> PreOrderInDB:
+    async def update_status(self, pre_order_id: str, new_status: PreOrderStatus, order_id: str | None = None) -> PreOrderInDB:
         try:
             pre_order_model: PreOrderModel = PreOrderModel.objects(
                 id=pre_order_id,
@@ -26,6 +26,11 @@ class PreOrderRepository(Repository):
 
             if new_status:
                 pre_order_model.status = new_status
+
+            if order_id is not None:
+                pre_order_model.order_id = order_id
+
+            if new_status or order_id is not None:
                 pre_order_model.save()
 
             return await self.select_by_id(id=pre_order_id)

--- a/app/crud/pre_orders/schemas.py
+++ b/app/crud/pre_orders/schemas.py
@@ -162,4 +162,4 @@ class UpdatePreOrder(GenericModel):
 
 
 class PreOrderInDB(PreOrder, DatabaseModel):
-    ...
+    order_id: str | None = Field(default=None, example="ord_123")

--- a/app/crud/pre_orders/services.py
+++ b/app/crud/pre_orders/services.py
@@ -52,10 +52,11 @@ class PreOrderServices:
         self.__cache_customers = {}
         self.__cache_offers = {}
 
-    async def update_status(self, pre_order_id: str, new_status: PreOrderStatus, expand: List[str] = []) -> PreOrderInDB:
+    async def update_status(self, pre_order_id: str, new_status: PreOrderStatus, order_id: str | None = None, expand: List[str] = []) -> PreOrderInDB:
         pre_order_in_db = await self.__pre_order_repository.update_status(
             pre_order_id=pre_order_id,
-            new_status=new_status
+            new_status=new_status,
+            order_id=order_id,
         )
 
         await self.send_client_message(
@@ -152,7 +153,9 @@ class PreOrderServices:
 
         order_in_db = await order_services.create(order=request_order)
         await self.update_status(
-            pre_order_id=pre_order_id, new_status=PreOrderStatus.ACCEPTED
+            pre_order_id=pre_order_id,
+            new_status=PreOrderStatus.ACCEPTED,
+            order_id=order_in_db.id,
         )
 
         return order_in_db

--- a/tests/crud/pre_orders/test_pre_orders_repository.py
+++ b/tests/crud/pre_orders/test_pre_orders_repository.py
@@ -40,8 +40,9 @@ class TestPreOrderRepository(unittest.IsolatedAsyncioTestCase):
     async def test_update_status(self):
         model = self._pre_order_model()
         model.save()
-        updated = await self.repo.update_status(model.id, PreOrderStatus.ACCEPTED)
+        updated = await self.repo.update_status(model.id, PreOrderStatus.ACCEPTED, order_id="ord1")
         self.assertEqual(updated.status, PreOrderStatus.ACCEPTED)
+        self.assertEqual(updated.order_id, "ord1")
 
     async def test_select_count_and_all(self):
         self._pre_order_model(code="A").save()

--- a/tests/crud/pre_orders/test_pre_orders_schemas.py
+++ b/tests/crud/pre_orders/test_pre_orders_schemas.py
@@ -43,3 +43,4 @@ class TestPreOrderSchemas(unittest.TestCase):
             is_active=True,
         )
         self.assertEqual(pre.code, "001")
+        self.assertIsNone(pre.order_id)

--- a/tests/crud/pre_orders/test_pre_orders_services.py
+++ b/tests/crud/pre_orders/test_pre_orders_services.py
@@ -179,11 +179,13 @@ class TestPreOrderServices(unittest.IsolatedAsyncioTestCase):
         self.organization_repo.select_by_id.return_value = DummyOrg()
 
         mock_order_services = AsyncMock()
-        mock_order_services.create.return_value = "order_created"
+        mock_order_services.create.return_value = SimpleNamespace(id="ord1")
 
         order = await self.service.accept_pre_order(pre.id, mock_order_services)
 
-        self.assertEqual(order, "order_created")
+        self.assertEqual(order.id, "ord1")
+        pre_in_db = await self.service.search_by_id(pre.id)
+        self.assertEqual(pre_in_db.order_id, "ord1")
         self.customer_repo.update.assert_awaited()
         updated_customer = self.customer_repo.update.call_args.kwargs["customer"]
         self.assertEqual(updated_customer.addresses[0].zip_code, "89066-000")
@@ -230,11 +232,11 @@ class TestPreOrderServices(unittest.IsolatedAsyncioTestCase):
         self.organization_repo.select_by_id.return_value = DummyOrg()
 
         mock_order_services = AsyncMock()
-        mock_order_services.create.return_value = "order_created"
+        mock_order_services.create.return_value = SimpleNamespace(id="ord1")
 
         order = await self.service.accept_pre_order(pre.id, mock_order_services)
 
-        self.assertEqual(order, "order_created")
+        self.assertEqual(order.id, "ord1")
         self.customer_repo.create.assert_awaited()
         created_customer_arg = self.customer_repo.create.call_args.kwargs["customer"]
         self.assertEqual(created_customer_arg.addresses[0].zip_code, "89066-000")


### PR DESCRIPTION
## Summary
- add optional `order_id` to pre-order model and schema
- persist the created order ID when a pre-order is accepted
- test order linkage in repository, schema, and service flows

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bedd383a58832a8e666570428b1ce9