### PR TITLE
Fix pre-order discount calculation to match order totals

### DIFF
--- a/app/crud/pre_orders/services.py
+++ b/app/crud/pre_orders/services.py
@@ -137,10 +137,13 @@ class PreOrderServices:
                     )
                 )
 
-                item_total = item.unit_price
-                for add in item.additionals:
-                    item_total += add.unit_price * add.quantity
-                item_total *= item.quantity
+                # ``offer_items_total`` must consider only the base price of each
+                # product. Additionals are charged separately and should not be
+                # used when calculating the discount. Including the additionals
+                # here would incorrectly subtract their price when the order is
+                # created, leading to a mismatch between the pre-order total and
+                # the final order total.
+                item_total = item.unit_price * item.quantity
                 offer_items_total += item_total
 
             offer_items_total *= offer.quantity


### PR DESCRIPTION
## Summary
- ensure offer discounts ignore additional items so order totals mirror pre-order totals
- add unit test confirming totals remain consistent when accepting pre-orders with offer additionals
- add regression test guaranteeing pre-order and order totals match after acceptance

## Testing
- `pip install -r requirements/dev.txt`
- `pytest tests/crud/pre_orders/test_pre_orders_services.py::TestPreOrderServices::test_accept_pre_order_total_amount_matches_order -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c24433b810832a9e06c93a3ed91d5c