### PR TITLE
Track user last access in metadata

### DIFF
--- a/app/api/routers/users/query_routers.py
+++ b/app/api/routers/users/query_routers.py
@@ -19,9 +19,12 @@ router = APIRouter(tags=["Users"])
 )
 async def current_user(
     current_user: UserInDB = Security(decode_jwt, scopes=["user:me"]),
+    user_services: UserServices = Depends(user_composer),
 ):
+    updated_user = await user_services.update_last_access(user=current_user)
+
     return build_response(
-        status_code=200, message="User found with success", data=current_user
+        status_code=200, message="User found with success", data=updated_user
     )
 
 

--- a/app/api/routers/users/schemas.py
+++ b/app/api/routers/users/schemas.py
@@ -11,7 +11,10 @@ EXAMPLE_USER = {
     "name": "Test",
     "nickname": "test",
     "picture": "http://localhost/image.png",
-    "user_metadata": {"phone": "123"},
+    "user_metadata": {
+        "phone": "123",
+        "last_access_at": "2024-01-01T12:00:00Z",
+    },
     "app_metadata": {},
     "last_login": "2024-01-01T00:00:00Z",
     "created_at": "2024-01-01T00:00:00Z",

--- a/app/crud/users/repositories.py
+++ b/app/crud/users/repositories.py
@@ -55,7 +55,10 @@ class UserRepository:
 
             if status_code == 200:
                 _logger.debug("User updated successfully")
-                return self.__mount_user(response)
+                updated_user = self.__mount_user(response)
+                self.__cache_users[user_id] = updated_user
+
+                return updated_user
 
             else:
                 _logger.warning(f"User {user_id} not updated")

--- a/app/crud/users/services.py
+++ b/app/crud/users/services.py
@@ -1,5 +1,7 @@
 from typing import Dict, List
 
+from app.core.utils.utc_datetime import UTCDateTime
+
 from .repositories import UserRepository
 from .schemas import UpdateUser, User, UserInDB
 
@@ -42,3 +44,20 @@ class UserServices:
 
         user_in_db = await self.__repository.delete_by_id(id=id)
         return user_in_db
+
+    async def update_last_access(self, user: UserInDB) -> UserInDB:
+        metadata = dict(user.user_metadata or {})
+        metadata["last_access_at"] = str(UTCDateTime.now())
+
+        updated_user = await self.__repository.update(
+            user_id=user.user_id,
+            user=UpdateUser(user_metadata=metadata)
+        )
+
+        self.__cached_complete_users.pop(user.user_id, None)
+
+        if updated_user:
+            return updated_user
+
+        user.user_metadata = metadata
+        return user

--- a/tests/api/routers/users/test_users_query_router.py
+++ b/tests/api/routers/users/test_users_query_router.py
@@ -1,0 +1,79 @@
+import unittest
+
+from fastapi.testclient import TestClient
+
+from app.api.composers import user_composer
+from app.api.dependencies.auth import decode_jwt
+from app.application import app
+from app.core.utils.utc_datetime import UTCDateTime
+from app.crud.users.schemas import UserInDB
+
+
+class MockUserServices:
+    def __init__(self, response_user: UserInDB):
+        self.response_user = response_user
+        self.called_with = None
+
+    async def update_last_access(self, user: UserInDB) -> UserInDB:
+        self.called_with = user
+        return self.response_user
+
+
+class TestUsersQueryRouter(unittest.TestCase):
+    def setUp(self):
+        self.current_user = UserInDB(
+            user_id="auth0|123",
+            email="user@test.com",
+            name="Test User",
+            nickname="test",
+            user_metadata={"phone": "123"},
+            created_at=UTCDateTime.now(),
+            updated_at=UTCDateTime.now(),
+        )
+
+        self.updated_user = UserInDB(
+            user_id=self.current_user.user_id,
+            email=self.current_user.email,
+            name=self.current_user.name,
+            nickname=self.current_user.nickname,
+            user_metadata={
+                **(self.current_user.user_metadata or {}),
+                "last_access_at": str(UTCDateTime.now()),
+            },
+            created_at=self.current_user.created_at,
+            updated_at=self.current_user.updated_at,
+        )
+
+        self.mock_service = MockUserServices(response_user=self.updated_user)
+
+        self.test_client = TestClient(app)
+
+        def override_decode_jwt():
+            return self.current_user
+
+        async def override_user_composer():
+            return self.mock_service
+
+        app.dependency_overrides[decode_jwt] = override_decode_jwt
+        app.dependency_overrides[user_composer] = override_user_composer
+        app.user_middleware.clear()
+
+    def tearDown(self) -> None:
+        app.dependency_overrides = {}
+
+    def test_get_current_user_updates_last_access(self):
+        response = self.test_client.get("/api/users/me/")
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+
+        self.assertEqual(payload["message"], "User found with success")
+        self.assertIsNotNone(self.mock_service.called_with)
+        self.assertEqual(self.mock_service.called_with.user_id, self.current_user.user_id)
+
+        metadata = payload["data"]["userMetadata"]
+        self.assertIn("last_access_at", metadata)
+        self.assertEqual(
+            metadata["last_access_at"],
+            self.updated_user.user_metadata["last_access_at"],
+        )

--- a/tests/crud/users/test_users_services.py
+++ b/tests/crud/users/test_users_services.py
@@ -1,0 +1,67 @@
+import unittest
+from unittest.mock import AsyncMock
+
+from app.core.utils.utc_datetime import UTCDateTime
+from app.crud.users.schemas import UserInDB
+from app.crud.users.services import UserServices
+
+
+class TestUserServices(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.repository = AsyncMock()
+        self.cached_complete_users = {}
+        self.service = UserServices(
+            user_repository=self.repository,
+            cached_complete_users=self.cached_complete_users,
+        )
+
+    async def _build_user(self, metadata=None) -> UserInDB:
+        return UserInDB(
+            user_id="auth0|123",
+            email="user@test.com",
+            name="Test User",
+            nickname="test",
+            user_metadata=metadata,
+            created_at=UTCDateTime.now(),
+            updated_at=UTCDateTime.now(),
+        )
+
+    async def test_update_last_access_adds_timestamp_and_clears_cache(self):
+        user = await self._build_user(metadata={"phone": "123"})
+        self.cached_complete_users[user.user_id] = object()
+
+        updated_metadata = {
+            "phone": "123",
+            "last_access_at": str(UTCDateTime.now()),
+        }
+        updated_user = await self._build_user(metadata=updated_metadata)
+        self.repository.update.return_value = updated_user
+
+        result = await self.service.update_last_access(user=user)
+
+        self.repository.update.assert_awaited_once()
+        call_kwargs = self.repository.update.await_args.kwargs
+        self.assertEqual(call_kwargs["user_id"], user.user_id)
+
+        payload_metadata = call_kwargs["user"].user_metadata
+        self.assertIn("last_access_at", payload_metadata)
+        self.assertEqual(payload_metadata["phone"], "123")
+        self.assertIsInstance(payload_metadata["last_access_at"], str)
+        UTCDateTime.validate_datetime(payload_metadata["last_access_at"])
+
+        self.assertNotIn(user.user_id, self.cached_complete_users)
+        self.assertEqual(result, updated_user)
+
+    async def test_update_last_access_initializes_metadata_when_missing(self):
+        user = await self._build_user(metadata=None)
+
+        updated_user = await self._build_user(
+            metadata={"last_access_at": str(UTCDateTime.now())}
+        )
+        self.repository.update.return_value = updated_user
+
+        result = await self.service.update_last_access(user=user)
+
+        payload_metadata = self.repository.update.await_args.kwargs["user"].user_metadata
+        self.assertIn("last_access_at", payload_metadata)
+        self.assertEqual(result, updated_user)


### PR DESCRIPTION
## Summary
- update the current user endpoint to refresh the last access timestamp inside user metadata using the user service
- extend the user service and repository so updates persist the timestamp and refresh the cached user payloads
- document the new metadata field and add unit plus router tests that cover the timestamp update behaviour

## Testing
- PYTHONPATH=. pytest tests/crud/users/test_users_services.py
- PYTHONPATH=. pytest tests/api/routers/users/test_users_query_router.py

------
https://chatgpt.com/codex/tasks/task_e_68c887b420fc832ab38ceb236c8a1149