### PR TITLE
Fix 500 when updating product additionals

### DIFF
--- a/app/api/routers/additionals/command_routers.py
+++ b/app/api/routers/additionals/command_routers.py
@@ -56,8 +56,6 @@ async def update_product_additional(
     current_user: UserInDB = Security(decode_jwt, scopes=["product_additional:create"]),
     product_additional_services: ProductAdditionalServices = Depends(product_additional_composer),
 ):
-    if product_additional.product_id is None:
-        product_additional.product_id = product_id
     additional_in_db = await product_additional_services.update(id=additional_id, updated_product_additional=product_additional)
 
     if additional_in_db:

--- a/tests/crud/product_additionals/test_product_additionals_services.py
+++ b/tests/crud/product_additionals/test_product_additionals_services.py
@@ -84,6 +84,21 @@ class TestProductAdditionalServices(unittest.IsolatedAsyncioTestCase):
         updated = await self.service.update(id=created.id, updated_product_additional=update)
         self.assertEqual(updated.name, "New")
 
+    async def test_update_product_additional_without_changes_returns_existing(self):
+        self.product_repo.select_by_id.return_value = "prod"
+        created = await self.service.create(await self._group(), product_id="prod1")
+
+        calls_before_update = self.product_repo.select_by_id.await_count
+
+        update = UpdateProductAdditional()
+        updated = await self.service.update(id=created.id, updated_product_additional=update)
+
+        self.assertEqual(self.product_repo.select_by_id.await_count, calls_before_update)
+        self.assertEqual(
+            updated.model_dump(exclude={"created_at", "updated_at"}),
+            created.model_dump(exclude={"created_at", "updated_at"}),
+        )
+
     async def test_update_product_additional_with_items(self):
         self.product_repo.select_by_id.return_value = "prod"
         created = await self.service.create(await self._group(), product_id="prod1")


### PR DESCRIPTION
## Summary
- remove the invalid access to `product_id` in the additional update route to prevent 500 errors
- add a regression test ensuring updates without changes return the stored model

## Testing
- pytest tests/crud/product_additionals/test_product_additionals_services.py -k update -vv

------
https://chatgpt.com/codex/tasks/task_e_68c9b39899ec832a93165aec4805bad0