### PR TITLE
feat: add accepts outside business hours flag to menu

### DIFF
--- a/app/api/routers/menus/schemas.py
+++ b/app/api/routers/menus/schemas.py
@@ -12,6 +12,7 @@ EXAMPLE_MENU = {
     "is_visible": True,
     "slug": "doces",
     "organization_id": "org_123",
+    "accepts_outside_business_hours": False,
 }
 
 

--- a/app/crud/menus/models.py
+++ b/app/crud/menus/models.py
@@ -21,6 +21,7 @@ class MenuModel(BaseDocument):
     km_tax = FloatField(required=False) # TODO remove that soon
     unit_tax = FloatField(required=False)
     accept_delivery: bool = BooleanField(default=True, required=False)
+    accepts_outside_business_hours: bool = BooleanField(default=False, required=False)
 
     meta = {
         "collection": "menus"

--- a/app/crud/menus/schemas.py
+++ b/app/crud/menus/schemas.py
@@ -22,6 +22,7 @@ class Menu(GenericModel):
     km_tax: float | None = Field(default=None, example=123)
     unit_tax: float | None = Field(default=None, example=123)
     accept_delivery: bool | None = Field(default=None, example=True)
+    accepts_outside_business_hours: bool = Field(default=False, example=False)
 
     def validate_updated_fields(self, update_menu: "UpdateMenu") -> bool:
         is_updated = False
@@ -82,6 +83,10 @@ class Menu(GenericModel):
             self.accept_delivery = update_menu.accept_delivery
             is_updated = True
 
+        if update_menu.accepts_outside_business_hours is not None:
+            self.accepts_outside_business_hours = update_menu.accepts_outside_business_hours
+            is_updated = True
+
         return is_updated
 
 
@@ -100,6 +105,7 @@ class UpdateMenu(GenericModel):
     km_tax: Optional[float] = Field(default=None, example=123)
     unit_tax: Optional[float] = Field(default=None, example=123)
     accept_delivery: Optional[bool] = Field(default=None, example=False)
+    accepts_outside_business_hours: Optional[bool] = Field(default=None, example=False)
 
 
 class MenuInDB(Menu, DatabaseModel):

--- a/tests/api/routers/menus/test_menus_command_router.py
+++ b/tests/api/routers/menus/test_menus_command_router.py
@@ -70,6 +70,7 @@ class TestMenusCommandRouter(unittest.TestCase):
         self.assertEqual(response.status_code, 201)
         self.assertEqual(json["message"], "Menu created with success")
         self.assertIsNotNone(json["data"]["id"])
+        self.assertFalse(json["data"]["acceptsOutsideBusinessHours"])
 
     @unittest.mock.patch("app.crud.menus.services.get_plan_feature")
     def test_post_menu_unauthorized(self, mock_get_plan_feature):
@@ -85,11 +86,12 @@ class TestMenusCommandRouter(unittest.TestCase):
         menu_id = self.insert_mock_menu(name="Old")
         response = self.test_client.put(
             f"/api/menus/{menu_id}",
-            json={"name": "Updated"},
+            json={"name": "Updated", "accepts_outside_business_hours": True},
             headers={"organization-id": "org_123"},
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["message"], "Menu updated with success")
+        self.assertTrue(response.json()["data"]["acceptsOutsideBusinessHours"])
 
     def test_put_menu_failure(self):
         response = self.test_client.put(

--- a/tests/api/routers/menus/test_menus_query_router.py
+++ b/tests/api/routers/menus/test_menus_query_router.py
@@ -48,6 +48,7 @@ class TestMenusQueryRouter(unittest.TestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["data"]["name"], "By ID")
+        self.assertFalse(response.json()["data"]["acceptsOutsideBusinessHours"])
         self.assertEqual(response.json()["message"], "Menu found with success")
 
     def test_get_menu_by_id_not_found(self):
@@ -68,6 +69,10 @@ class TestMenusQueryRouter(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["message"], "Menus found with success")
         self.assertGreaterEqual(len(response.json()["data"]), 2)
+        self.assertIn(
+            False,
+            [menu["acceptsOutsideBusinessHours"] for menu in response.json()["data"]],
+        )
 
     def test_get_menus_empty_returns_204(self):
         response = self.test_client.get(

--- a/tests/crud/menus/test_menus_repository.py
+++ b/tests/crud/menus/test_menus_repository.py
@@ -30,6 +30,7 @@ class TestMenuRepository(unittest.IsolatedAsyncioTestCase):
         result = await self.repo.create(menu)
         self.assertEqual(result.name, "Lunch")
         self.assertEqual(result.slug, "lunch")
+        self.assertFalse(result.accepts_outside_business_hours)
         self.assertEqual(MenuModel.objects.count(), 1)
 
     async def test_create_duplicate_menu_raises_error(self):
@@ -52,6 +53,13 @@ class TestMenuRepository(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(updated.name, "New")
         self.assertEqual(updated.slug, "new")
 
+    async def test_update_menu_accepts_outside_business_hours(self):
+        created = await self.repo.create(await self._menu(name="Outside"))
+        created.accepts_outside_business_hours = True
+        updated = await self.repo.update(created)
+
+        self.assertTrue(updated.accepts_outside_business_hours)
+
     async def test_update_menu_not_unique(self):
         first = await self.repo.create(await self._menu(name="A"))
         await self.repo.create(await self._menu(name="B"))
@@ -63,6 +71,7 @@ class TestMenuRepository(unittest.IsolatedAsyncioTestCase):
         created = await self.repo.create(await self._menu())
         result = await self.repo.select_by_id(id=created.id)
         self.assertEqual(result.id, created.id)
+        self.assertFalse(result.accepts_outside_business_hours)
 
     async def test_select_by_id_not_found(self):
         with self.assertRaises(NotFoundError):

--- a/tests/crud/menus/test_menus_services.py
+++ b/tests/crud/menus/test_menus_services.py
@@ -41,6 +41,7 @@ class TestMenuServices(unittest.IsolatedAsyncioTestCase):
         result = await self.service.create(await self._menu(name="New"))
         self.assertEqual(result.name, "New")
         self.assertEqual(result.slug, "new")
+        self.assertFalse(result.accepts_outside_business_hours)
 
     async def _create_menu_in_db(self, name="Menu"):
         repo = self.service._MenuServices__menu_repository
@@ -48,9 +49,16 @@ class TestMenuServices(unittest.IsolatedAsyncioTestCase):
 
     async def test_update_menu(self):
         created = await self._create_menu_in_db(name="Old")
-        updated = await self.service.update(id=created.id, updated_menu=UpdateMenu(name="New"))
+        updated = await self.service.update(
+            id=created.id,
+            updated_menu=UpdateMenu(
+                name="New",
+                accepts_outside_business_hours=True,
+            ),
+        )
         self.assertEqual(updated.name, "New")
         self.assertEqual(updated.slug, "new")
+        self.assertTrue(updated.accepts_outside_business_hours)
 
     async def test_search_all(self):
         mock_repo = AsyncMock()


### PR DESCRIPTION
## Summary
- add the accepts_outside_business_hours flag to the menu model and schema
- ensure menu validation supports updating the new flag and expose it via API examples
- expand repository, service and router tests to cover the new field defaults and updates

## Testing
- pytest tests/crud/menus/test_menus_repository.py tests/crud/menus/test_menus_services.py tests/api/routers/menus/test_menus_query_router.py tests/api/routers/menus/test_menus_command_router.py

------
https://chatgpt.com/codex/tasks/task_e_68d44d93429c832ab477bb02fc8bd1ee