### PR TITLE
Add organization flag to control order notifications

### DIFF
--- a/app/crud/orders/message_manager.py
+++ b/app/crud/orders/message_manager.py
@@ -70,6 +70,9 @@ class OrderMessageManager:
             id=organization_id
         )
 
+        if not getattr(organization, "enable_order_notifications", False):
+            return
+
         if order.status == OrderStatus.OUT_FOR_DELIVERY:
             title = "*Seu pedido saiu para entrega!*"
             body = "Informamos que seu pedido saiu para entrega e chegará em breve!"

--- a/app/crud/organizations/models.py
+++ b/app/crud/organizations/models.py
@@ -1,4 +1,4 @@
-from mongoengine import DictField, ListField, StringField, FloatField
+from mongoengine import BooleanField, DictField, ListField, StringField, FloatField
 
 from app.core.models.base_document import BaseDocument
 from app.core.utils.utc_datetime import UTCDateTime
@@ -22,6 +22,7 @@ class OrganizationModel(BaseDocument):
     website = StringField(required=False, default=None)
     social_links = DictField(required=False, default=None)
     styling = DictField(required=False, default=None)
+    enable_order_notifications = BooleanField(required=False, default=False)
 
     meta = {"collection": "organizations"}
 

--- a/app/crud/organizations/schemas.py
+++ b/app/crud/organizations/schemas.py
@@ -50,6 +50,7 @@ class Organization(GenericModel):
     website: str | None = Field(default=None, example="https://your_company.com")
     social_links: SocialLinks | None = Field(default=None)
     styling: Styling | None = Field(default=None)
+    enable_order_notifications: bool = Field(default=False)
 
     @model_validator(mode="after")
     def validate_model(self) -> "Organization":
@@ -151,6 +152,12 @@ class Organization(GenericModel):
             self.styling = update_organization.styling
             is_updated = True
 
+        if update_organization.enable_order_notifications is not None:
+            self.enable_order_notifications = (
+                update_organization.enable_order_notifications
+            )
+            is_updated = True
+
         return is_updated
 
 
@@ -170,6 +177,7 @@ class UpdateOrganization(GenericModel):
     website: Optional[str] = Field(default=None)
     social_links: Optional[SocialLinks] = Field(default=None)
     styling: Optional[Styling] = Field(default=None)
+    enable_order_notifications: Optional[bool] = Field(default=None)
 
     @model_validator(mode="after")
     def validate_model(self) -> "UpdateOrganization":

--- a/app/crud/pre_orders/services.py
+++ b/app/crud/pre_orders/services.py
@@ -208,6 +208,9 @@ class PreOrderServices:
             id=self.__pre_order_repository.organization_id
         )
 
+        if not getattr(organization, "enable_order_notifications", False):
+            return False
+
         status = "ACEITO" if pre_order.status.startswith("A") else "RECUSADO"
 
         text_message = f"""*Seu pedido foi atualizado!*

--- a/tests/crud/orders/test_orders_services.py
+++ b/tests/crud/orders/test_orders_services.py
@@ -1090,6 +1090,7 @@ class TestOrderServices(unittest.IsolatedAsyncioTestCase):
             international_code="55",
             ddd="047",
             phone_number="111111111",
+            enable_order_notifications=True,
         )
 
         message_services = self._message_services()
@@ -1150,6 +1151,7 @@ class TestOrderServices(unittest.IsolatedAsyncioTestCase):
             international_code="55",
             ddd="047",
             phone_number="111111111",
+            enable_order_notifications=True,
         )
 
         message_services = self._message_services()

--- a/tests/crud/pre_orders/test_pre_orders_services.py
+++ b/tests/crud/pre_orders/test_pre_orders_services.py
@@ -14,6 +14,7 @@ class DummyOrg:
     international_code = "55"
     ddd = "047"
     phone_number = "123456789"
+    enable_order_notifications = True
 
 
 class TestPreOrderServices(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
## Summary
- add an `enable_order_notifications` boolean field to organization data with a default of false
- prevent order and pre-order services from sending WhatsApp notifications to customers when the new flag is disabled

## Testing
- pytest *(fails: missing dependencies such as fastapi, mongoengine, boto3)*

------
https://chatgpt.com/codex/tasks/task_e_68d6025f4bc4832aa42507933c599327