### PR TITLE
Add unit tests for core utility modules

### DIFF
--- a/tests/core/utils/test_features.py
+++ b/tests/core/utils/test_features.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from app.core.utils.features import Feature, get_translation
+
+
+@pytest.mark.parametrize(
+    "feature, expected",
+    (
+        (Feature.MAX_USERS, "Usuários"),
+        (Feature.MAX_PRODUCTS, "Produtos"),
+        (Feature.DISPLAY_DASHBOARD, "Painel financeiro"),
+        (Feature.SUPPORT, "Suporte via WhatsApp"),
+    ),
+)
+def test_get_translation_returns_expected_label(feature: Feature, expected: str) -> None:
+    assert get_translation(feature) == expected
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    (
+        ("-", "Ilimitado"),
+        ("true", "Incluído"),
+        ("false", "Não incluído"),
+    ),
+)
+def test_get_translation_handles_special_string_values(raw: str, expected: str) -> None:
+    assert get_translation(raw) == expected
+
+
+def test_get_translation_returns_none_for_unknown_feature() -> None:
+    assert get_translation("UNKNOWN") is None

--- a/tests/core/utils/test_permissions.py
+++ b/tests/core/utils/test_permissions.py
@@ -1,0 +1,62 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from app.core.utils.permissions import get_role_permissions
+from app.crud.shared_schemas.roles import RoleEnum
+
+
+@pytest.fixture(scope="module")
+def base_permissions() -> set[str]:
+    return {
+        "tag:get",
+        "product:get",
+        "product_additional:get",
+        "user:me",
+        "payment:get",
+        "order:create",
+        "order:get",
+        "fast_order:create",
+        "fast_order:get",
+        "expense:create",
+        "expense:get",
+        "customer:create",
+        "customer:get",
+        "subscription:get",
+        "calendar:get",
+        "section:get",
+        "pre-order:get",
+        "business_day:get",
+    }
+
+
+def test_member_has_only_base_permissions(base_permissions: set[str]) -> None:
+    assert get_role_permissions(RoleEnum.MEMBER) == base_permissions
+
+
+def test_manager_inherits_manager_and_admin_permissions(base_permissions: set[str]) -> None:
+    permissions = get_role_permissions(RoleEnum.MANAGER)
+
+    assert base_permissions.issubset(permissions)
+    assert "tag:create" in permissions
+    assert "user:create" in permissions  # admin-level permission shared with managers
+    assert "organization:delete" not in permissions
+
+
+def test_admin_has_management_permissions_but_not_owner_specific() -> None:
+    permissions = get_role_permissions(RoleEnum.ADMIN)
+
+    assert "tag:create" in permissions
+    assert "organization:update" in permissions
+    assert "organization:delete" not in permissions
+
+
+def test_owner_has_full_permission_set_including_owner_specific() -> None:
+    permissions = get_role_permissions(RoleEnum.OWNER)
+
+    assert "organization:delete" in permissions
+    assert "subscription:create" in permissions
+    assert "subscription:delete" in permissions

--- a/tests/core/utils/test_utc_datetime.py
+++ b/tests/core/utils/test_utc_datetime.py
@@ -1,0 +1,77 @@
+from datetime import datetime
+from pathlib import Path
+import sys
+
+import pytest
+import pytz
+from pydantic import BaseModel
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from app.core.utils.utc_datetime import UTCDateTime, UTCDateTimeType
+
+
+def test_utc_datetime_defaults_to_utc() -> None:
+    dt = UTCDateTime(2024, 1, 1, 12, 30, 15)
+
+    assert dt.tzinfo is pytz.UTC
+    assert str(dt).endswith("Z")
+
+
+def test_utc_datetime_converts_from_aware_timezone() -> None:
+    eastern = pytz.timezone("US/Eastern")
+    aware = eastern.localize(datetime(2024, 1, 1, 7, 30, 15))
+
+    converted = UTCDateTime(
+        aware.year,
+        aware.month,
+        aware.day,
+        aware.hour,
+        aware.minute,
+        aware.second,
+        aware.microsecond,
+        tzinfo=aware.tzinfo,
+    )
+
+    assert converted.tzinfo is pytz.UTC
+    assert converted.hour == 12
+    assert converted.minute == 30
+
+
+def test_utc_datetime_timestamp_returns_integer() -> None:
+    dt = UTCDateTime(1970, 1, 1, 0, 0, 5)
+
+    assert dt.timestamp() == 5
+
+
+@pytest.mark.parametrize(
+    "value",
+    (
+        "2024-01-01T12:00:00Z",
+        "2024-01-01T09:00:00-03:00",
+        "2024-01-01T12:00:00",
+        datetime(2024, 1, 1, 12, 0, 0),
+        pytz.timezone("US/Pacific").localize(datetime(2024, 1, 1, 4, 0, 0)),
+    ),
+)
+def test_validate_datetime_accepts_multiple_formats(value) -> None:
+    parsed = UTCDateTime.validate_datetime(value)
+
+    assert isinstance(parsed, UTCDateTime)
+    assert parsed.tzinfo is pytz.UTC
+
+
+def test_validate_datetime_raises_value_error_for_invalid_input() -> None:
+    with pytest.raises(ValueError):
+        UTCDateTime.validate_datetime(42)
+
+
+class _UTCModel(BaseModel):
+    timestamp: UTCDateTimeType
+
+
+def test_utc_datetime_type_integrates_with_pydantic() -> None:
+    model = _UTCModel(timestamp="2024-01-01T12:00:00Z")
+
+    assert isinstance(model.timestamp, UTCDateTime)
+    assert model.model_dump()["timestamp"].tzinfo is pytz.UTC

--- a/tests/core/utils/test_validate_document.py
+++ b/tests/core/utils/test_validate_document.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from app.core.utils.validate_document import validate_cpf, validate_cnpj
+
+
+@pytest.mark.parametrize(
+    "cpf, expected",
+    (
+        ("52998224725", True),
+        ("12345678909", True),
+        ("00000000000", False),
+        ("52998224724", False),
+        ("123", False),
+    ),
+)
+def test_validate_cpf(cpf: str, expected: bool) -> None:
+    assert validate_cpf(cpf) is expected
+
+
+@pytest.mark.parametrize(
+    "cnpj, expected",
+    (
+        ("11444777000161", True),
+        ("04252011000110", True),
+        ("00000000000000", False),
+        ("11444777000160", False),
+        ("123456789012", False),
+    ),
+)
+def test_validate_cnpj(cnpj: str, expected: bool) -> None:
+    assert validate_cnpj(cnpj) is expected


### PR DESCRIPTION
## Summary
- add parametrized coverage for feature translations and permission resolution helpers
- exercise CPF/CNPJ validation routines with valid and invalid documents
- verify UTCDateTime helpers handle conversions, serialization, and Pydantic integration

## Testing
- pytest --cov=app/ -q

------
https://chatgpt.com/codex/tasks/task_e_68d780979728832aa739f4a299c0049b