### PR TITLE
Use existing search_by_cep for organization ZIP validation

### DIFF
--- a/app/api/composers/organization_composite.py
+++ b/app/api/composers/organization_composite.py
@@ -3,6 +3,8 @@ from fastapi import Depends
 from app.api.dependencies.cache_plans import get_cached_plans
 from app.api.dependencies.cache_users import get_cached_complete_users, get_cached_users
 from app.api.dependencies.get_access_token import get_access_token
+from app.crud.addresses.repositories import AddressRepository
+from app.crud.addresses.services import AddressServices
 from app.crud.organization_plans.repositories import OrganizationPlanRepository
 from app.crud.organizations.repositories import OrganizationRepository
 from app.crud.organizations.services import OrganizationServices
@@ -25,9 +27,14 @@ async def organization_composer(
         cache_plans=cache_plans
     )
 
+    address_services = AddressServices(
+        address_repository=AddressRepository()
+    )
+
     organization_services = OrganizationServices(
         organization_repository=organization_repository,
         organization_plan_repository=organization_plan_repository,
+        address_services=address_services,
         user_repository=user_repository,
         cached_complete_users=cached_complete_users,
     )

--- a/app/crud/addresses/services.py
+++ b/app/crud/addresses/services.py
@@ -1,4 +1,5 @@
 from typing import List
+
 from app.core.exceptions import NotFoundError, UnprocessableEntity
 from app.core.utils.coordinator import Coordinator
 from app.core.utils.get_address_by_zip_code import get_address_by_zip_code

--- a/tests/api/routers/organizations/test_organizations_command_router.py
+++ b/tests/api/routers/organizations/test_organizations_command_router.py
@@ -35,6 +35,8 @@ class TestOrganizationsCommandRouter(unittest.TestCase):
         self.repo = OrganizationRepository()
         self.user_repo = AsyncMock()
         self.plan_repo = AsyncMock()
+        self.address_service = AsyncMock()
+        self.address_service.search_by_cep = AsyncMock(return_value=None)
 
         patcher_email = patch(
             "app.crud.organizations.services.send_email", return_value="id"
@@ -46,6 +48,7 @@ class TestOrganizationsCommandRouter(unittest.TestCase):
             organization_repository=self.repo,
             user_repository=self.user_repo,
             organization_plan_repository=self.plan_repo,
+            address_services=self.address_service,
             cached_complete_users={},
         )
 

--- a/tests/api/routers/organizations/test_organizations_query_router.py
+++ b/tests/api/routers/organizations/test_organizations_query_router.py
@@ -39,11 +39,14 @@ class TestOrganizationsQueryRouter(unittest.TestCase):
         self.repo = OrganizationRepository()
         self.user_repo = AsyncMock()
         self.plan_repo = AsyncMock()
+        self.address_service = AsyncMock()
+        self.address_service.search_by_cep = AsyncMock(return_value=None)
 
         self.service = OrganizationServices(
             organization_repository=self.repo,
             user_repository=self.user_repo,
             organization_plan_repository=self.plan_repo,
+            address_services=self.address_service,
             cached_complete_users={},
         )
 


### PR DESCRIPTION
## Summary
- update organization ZIP validation to call the existing `AddressServices.search_by_cep` helper
- remove the redundant `get_by_zip_code` helper from `AddressServices`
- adjust organization service and router tests to mock `search_by_cep`

## Testing
- pytest tests/crud/organizations/test_organizations_services.py *(fails: ModuleNotFoundError: No module named 'mongomock')*

------
https://chatgpt.com/codex/tasks/task_e_68d8c317d24c832a811dd2e9a0b57a62