### PR TITLE
Run plan expiration notification in background on /users/me

### DIFF
--- a/app/api/composers/user_composite.py
+++ b/app/api/composers/user_composite.py
@@ -1,7 +1,9 @@
 from fastapi import Depends
 
+from app.api.composers.organization_plan_composite import organization_plan_composer
 from app.api.dependencies.cache_users import get_cached_complete_users, get_cached_users
 from app.api.dependencies.get_access_token import get_access_token
+from app.crud.organizations.repositories import OrganizationRepository
 from app.crud.users.repositories import UserRepository
 from app.crud.users.services import UserServices
 
@@ -10,13 +12,19 @@ async def user_composer(
     access_token=Depends(get_access_token),
     cached_complete_users=Depends(get_cached_complete_users),
     cached_users=Depends(get_cached_users),
+    organization_plan_services=Depends(organization_plan_composer),
 ) -> UserServices:
     user_repository = UserRepository(
         access_token=access_token,
         cache_users=cached_users
     )
 
+    organization_repository = OrganizationRepository()
+
     user_services = UserServices(
-        user_repository=user_repository, cached_complete_users=cached_complete_users
+        user_repository=user_repository,
+        cached_complete_users=cached_complete_users,
+        organization_plan_services=organization_plan_services,
+        organization_repository=organization_repository,
     )
     return user_services

--- a/app/crud/users/services.py
+++ b/app/crud/users/services.py
@@ -1,9 +1,22 @@
-from typing import Dict, List
+from __future__ import annotations
 
+import math
+from datetime import timedelta
+from typing import Dict, List, TYPE_CHECKING
+
+from app.api.dependencies.email_sender import send_email
+from app.core.configs import get_logger
 from app.core.utils.utc_datetime import UTCDateTime
-
 from .repositories import UserRepository
 from .schemas import UpdateUser, User, UserInDB
+
+
+_logger = get_logger(__name__)
+
+
+if TYPE_CHECKING:  # pragma: no cover - type checking only
+    from app.crud.organization_plans.services import OrganizationPlanServices
+    from app.crud.organizations.repositories import OrganizationRepository
 
 
 class UserServices:
@@ -12,9 +25,13 @@ class UserServices:
         self,
         user_repository: UserRepository,
         cached_complete_users: Dict[str, UserInDB],
+        organization_plan_services: OrganizationPlanServices | None = None,
+        organization_repository: OrganizationRepository | None = None,
     ) -> None:
         self.__repository = user_repository
         self.__cached_complete_users = cached_complete_users
+        self.__organization_plan_services = organization_plan_services
+        self.__organization_repository = organization_repository
 
     # async def create(self, user: User) -> UserInDB:
     #     user_in_db = await self.__repository.create(user=user, password=password)
@@ -61,3 +78,129 @@ class UserServices:
 
         user.user_metadata = metadata
         return user
+
+    async def notify_plan_expiration(self, user: UserInDB) -> None:
+        if not self.__organization_plan_services:
+            return
+
+        organizations = getattr(user, "organizations", []) or []
+
+        if not organizations:
+            return
+
+        metadata = dict(user.user_metadata or {})
+        raw_notifications = metadata.get("plan_expiration_notifications")
+
+        notifications: Dict[str, str] = {}
+
+        if isinstance(raw_notifications, dict):
+            notifications = dict(raw_notifications)
+
+        now = UTCDateTime.now()
+        limit = now + timedelta(days=7)
+        metadata_updated = False
+
+        for organization_id in organizations:
+            try:
+                plan = await self.__organization_plan_services.search_active_plan(
+                    organization_id=organization_id
+                )
+            except Exception as error:  # pragma: no cover - defensive
+                _logger.error(
+                    "Error when checking active plan for organization %s: %s",
+                    organization_id,
+                    str(error),
+                )
+                continue
+
+            if not plan or not plan.calculate_active_plan():
+                continue
+
+            if plan.end_date < now or plan.end_date > limit:
+                continue
+
+            if notifications.get(plan.id):
+                continue
+
+            organization_name = organization_id
+
+            if self.__organization_repository:
+                try:
+                    organization_in_db = await self.__organization_repository.select_by_id(
+                        id=organization_id
+                    )
+                    if organization_in_db:
+                        organization_name = getattr(organization_in_db, "name", organization_name)
+                except Exception as error:  # pragma: no cover - defensive
+                    _logger.warning(
+                        "Unable to fetch organization %s name: %s",
+                        organization_id,
+                        str(error),
+                    )
+
+            days_left = max(
+                1,
+                math.ceil((plan.end_date - now).total_seconds() / 86400),
+            )
+
+            message = self.__build_plan_expiration_email(
+                user_name=user.name,
+                organization_name=organization_name,
+                end_date=plan.end_date,
+                days_left=days_left,
+            )
+
+            if not message:
+                continue
+
+            send_email(
+                email_to=[user.email],
+                title="PedidoZ - Seu plano está quase expirando",
+                message=message,
+            )
+
+            notifications[plan.id] = str(UTCDateTime.now())
+            metadata_updated = True
+
+        if metadata_updated:
+            metadata["plan_expiration_notifications"] = notifications
+            user.user_metadata = metadata
+
+            await self.__repository.update(
+                user_id=user.user_id,
+                user=UpdateUser(user_metadata=metadata),
+            )
+
+            self.__cached_complete_users.pop(user.user_id, None)
+
+    def __build_plan_expiration_email(
+        self,
+        user_name: str,
+        organization_name: str,
+        end_date: UTCDateTime,
+        days_left: int,
+    ) -> str | None:
+        try:
+            with open(
+                "./templates/organization-plan-expiration-email.html",
+                mode="r",
+                encoding="UTF-8",
+            ) as template_file:
+                message = template_file.read()
+
+            return (
+                message.replace("$USER_NAME$", user_name.title())
+                .replace("$ORGANIZATION_NAME$", organization_name)
+                .replace("$PLAN_END_DATE$", end_date.strftime("%d/%m/%Y"))
+                .replace("$DAYS_LEFT$", str(days_left))
+            )
+        except FileNotFoundError:
+            _logger.error("Organization plan expiration template not found")
+        except Exception as error:  # pragma: no cover - defensive
+            _logger.error(
+                "Error when building plan expiration email for %s: %s",
+                user_name,
+                str(error),
+            )
+
+        return None

--- a/templates/organization-plan-expiration-email.html
+++ b/templates/organization-plan-expiration-email.html
@@ -1,0 +1,35 @@
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Seu plano está quase expirando</title>
+</head>
+<body style="font-family: Arial, sans-serif; line-height: 1.6; color: #CFD2C7; background-color: #0F1115; margin: 0; padding: 24px;">
+    <table cellpadding="0" cellspacing="0" width="100%" style="max-width: 640px; margin: 0 auto; background-color: #1E2122; border-radius: 12px; box-shadow: 0 12px 30px rgba(0,0,0,0.35);">
+        <tr>
+            <td style="padding: 36px;">
+                <h1 style="color: #E57D1C; margin-bottom: 20px; font-size: 28px; text-align: center;">$USER_NAME$, seu plano está quase expirando! ⚠️</h1>
+                <p style="margin-bottom: 20px; font-size: 16px;">Olá, $USER_NAME$!</p>
+                <p style="margin-bottom: 20px; font-size: 16px;">
+                    O plano da organização <strong style="color: #E57D1C;">$ORGANIZATION_NAME$</strong> expira em <strong>$DAYS_LEFT$ dia(s)</strong>, no dia <strong>$PLAN_END_DATE$</strong>.
+                </p>
+                <p style="margin-bottom: 20px; font-size: 16px;">
+                    Para garantir que você continue aproveitando todos os recursos da PedidoZ sem interrupções, recomendamos renovar o plano o quanto antes.
+                </p>
+                <p style="margin-bottom: 30px; font-size: 16px;">
+                    Se tiver qualquer dúvida ou precisar de ajuda com o processo, é só responder este e-mail ou chamar nossa equipe pelo WhatsApp em <a href="https://wa.me/5547988355092" style="color: #E57D1C; text-decoration: none;">(47) 98835-5092</a>.
+                </p>
+                <table cellpadding="0" cellspacing="0" width="100%" style="margin-bottom: 30px;">
+                    <tr>
+                        <td align="center">
+                            <a href="https://pedidoz.online" style="display: inline-block; background-color: #E57D1C; color: #121516; text-decoration: none; padding: 14px 30px; border-radius: 6px; font-weight: bold; font-size: 16px;">Renovar meu plano</a>
+                        </td>
+                    </tr>
+                </table>
+                <p style="margin-bottom: 10px; font-size: 16px;">Conte sempre conosco!</p>
+                <p style="margin: 0; font-size: 16px;">Abraços, Equipe PedidoZ</p>
+            </td>
+        </tr>
+    </table>
+</body>
+</html>

--- a/tests/crud/users/test_users_services.py
+++ b/tests/crud/users/test_users_services.py
@@ -1,8 +1,11 @@
 import unittest
-from unittest.mock import AsyncMock
+from datetime import timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
 
 from app.core.utils.utc_datetime import UTCDateTime
-from app.crud.users.schemas import UserInDB
+from app.crud.organization_plans.schemas import OrganizationPlanInDB
+from app.crud.users.schemas import CompleteUserInDB, UserInDB
 from app.crud.users.services import UserServices
 
 
@@ -10,13 +13,19 @@ class TestUserServices(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         self.repository = AsyncMock()
         self.cached_complete_users = {}
+        self.organization_plan_services = AsyncMock()
+        self.organization_plan_services.search_active_plan = AsyncMock()
+        self.organization_repository = AsyncMock()
+        self.organization_repository.select_by_id = AsyncMock()
         self.service = UserServices(
             user_repository=self.repository,
             cached_complete_users=self.cached_complete_users,
+            organization_plan_services=self.organization_plan_services,
+            organization_repository=self.organization_repository,
         )
 
-    async def _build_user(self, metadata=None) -> UserInDB:
-        return UserInDB(
+    async def _build_user(self, metadata=None, complete=False, organizations=None) -> UserInDB:
+        base_payload = dict(
             user_id="auth0|123",
             email="user@test.com",
             name="Test User",
@@ -25,6 +34,15 @@ class TestUserServices(unittest.IsolatedAsyncioTestCase):
             created_at=UTCDateTime.now(),
             updated_at=UTCDateTime.now(),
         )
+
+        if complete:
+            return CompleteUserInDB(
+                **base_payload,
+                organizations=organizations or [],
+                organizations_roles={},
+            )
+
+        return UserInDB(**base_payload)
 
     async def test_update_last_access_adds_timestamp_and_clears_cache(self):
         user = await self._build_user(metadata={"phone": "123"})
@@ -65,3 +83,83 @@ class TestUserServices(unittest.IsolatedAsyncioTestCase):
         payload_metadata = self.repository.update.await_args.kwargs["user"].user_metadata
         self.assertIn("last_access_at", payload_metadata)
         self.assertEqual(result, updated_user)
+
+    async def test_notify_plan_expiration_sends_email_and_updates_metadata(self):
+        user = await self._build_user(metadata={"phone": "123"}, complete=True, organizations=["org_1"])
+        self.cached_complete_users[user.user_id] = object()
+
+        plan = OrganizationPlanInDB(
+            id="org_plan_1",
+            plan_id="plan_basic",
+            organization_id="org_1",
+            start_date=UTCDateTime.now() - timedelta(days=5),
+            end_date=UTCDateTime.now() + timedelta(days=2),
+            allow_additional=False,
+            has_paid_invoice=True,
+            created_at=UTCDateTime.now() - timedelta(days=10),
+            updated_at=UTCDateTime.now() - timedelta(days=1),
+        )
+
+        self.organization_plan_services.search_active_plan.return_value = plan
+        self.organization_repository.select_by_id.return_value = SimpleNamespace(name="Org Test")
+        self.repository.update.return_value = user
+
+        with patch("app.crud.users.services.send_email") as send_email_mock:
+            await self.service.notify_plan_expiration(user=user)
+
+        send_email_mock.assert_called_once()
+        self.organization_plan_services.search_active_plan.assert_awaited_once()
+        self.organization_repository.select_by_id.assert_awaited_once_with(id="org_1")
+        self.repository.update.assert_awaited_once()
+        self.assertNotIn(user.user_id, self.cached_complete_users)
+
+        notifications = user.user_metadata.get("plan_expiration_notifications")
+        self.assertIn(plan.id, notifications)
+        UTCDateTime.validate_datetime(notifications[plan.id])
+
+    async def test_notify_plan_expiration_skips_when_already_notified(self):
+        metadata = {"plan_expiration_notifications": {"org_plan_1": str(UTCDateTime.now())}}
+        user = await self._build_user(metadata=metadata, complete=True, organizations=["org_1"])
+
+        plan = OrganizationPlanInDB(
+            id="org_plan_1",
+            plan_id="plan_basic",
+            organization_id="org_1",
+            start_date=UTCDateTime.now() - timedelta(days=5),
+            end_date=UTCDateTime.now() + timedelta(days=3),
+            allow_additional=False,
+            has_paid_invoice=True,
+            created_at=UTCDateTime.now() - timedelta(days=10),
+            updated_at=UTCDateTime.now() - timedelta(days=1),
+        )
+
+        self.organization_plan_services.search_active_plan.return_value = plan
+
+        with patch("app.crud.users.services.send_email") as send_email_mock:
+            await self.service.notify_plan_expiration(user=user)
+
+        send_email_mock.assert_not_called()
+        self.repository.update.assert_not_called()
+
+    async def test_notify_plan_expiration_ignores_plans_outside_window(self):
+        user = await self._build_user(metadata={}, complete=True, organizations=["org_1"])
+
+        plan = OrganizationPlanInDB(
+            id="org_plan_1",
+            plan_id="plan_basic",
+            organization_id="org_1",
+            start_date=UTCDateTime.now() - timedelta(days=5),
+            end_date=UTCDateTime.now() + timedelta(days=10),
+            allow_additional=False,
+            has_paid_invoice=True,
+            created_at=UTCDateTime.now() - timedelta(days=10),
+            updated_at=UTCDateTime.now() - timedelta(days=1),
+        )
+
+        self.organization_plan_services.search_active_plan.return_value = plan
+
+        with patch("app.crud.users.services.send_email") as send_email_mock:
+            await self.service.notify_plan_expiration(user=user)
+
+        send_email_mock.assert_not_called()
+        self.repository.update.assert_not_called()


### PR DESCRIPTION
## Summary
- queue plan expiration notification and last access update to run in the background for the /users/me endpoint

## Testing
- PYTHONPATH=. pytest tests/api/routers/users/test_users_query_router.py tests/crud/users/test_users_services.py *(fails: missing FastAPI/Pydantic dependencies in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9ed2bd124832ab2862844a3360dea