### PR TITLE
Add notification management module with email delivery

### DIFF
--- a/app/api/composers/__init__.py
+++ b/app/api/composers/__init__.py
@@ -28,3 +28,4 @@ from .pre_order_composite import pre_order_composer
 from .message_composite import message_composer
 from .product_additional_composite import product_additional_composer
 from .business_day_composite import business_day_composer
+from .notification_composite import notification_composer

--- a/app/api/composers/notification_composite.py
+++ b/app/api/composers/notification_composite.py
@@ -1,0 +1,21 @@
+from datetime import timedelta
+
+from fastapi import Depends
+
+from app.api.dependencies.get_current_organization import check_current_organization
+
+from app.crud.notifications.repositories import NotificationRepository
+from app.crud.notifications.services import NotificationServices
+
+
+async def notification_composer(
+    organization_id: str = Depends(check_current_organization),
+) -> NotificationServices:
+    notification_repository = NotificationRepository(
+        organization_id=organization_id,
+    )
+    notification_services = NotificationServices(
+        notification_repository=notification_repository,
+        deduplication_interval=timedelta(minutes=10),
+    )
+    return notification_services

--- a/app/api/routers/__init__.py
+++ b/app/api/routers/__init__.py
@@ -28,3 +28,4 @@ from .pre_orders import pre_order_router
 from .messages import message_router
 from .additionals import additional_router
 from .business_days import business_day_router
+from .notifications import notification_router

--- a/app/api/routers/notifications/__init__.py
+++ b/app/api/routers/notifications/__init__.py
@@ -1,0 +1,9 @@
+from fastapi import APIRouter
+
+from .command_routers import router as command_router
+from .query_routers import router as query_router
+
+
+notification_router = APIRouter()
+notification_router.include_router(command_router)
+notification_router.include_router(query_router)

--- a/app/api/routers/notifications/command_routers.py
+++ b/app/api/routers/notifications/command_routers.py
@@ -1,0 +1,40 @@
+from fastapi import APIRouter, Depends, status
+
+from app.api.composers import notification_composer
+from app.api.dependencies import build_response
+from app.crud.notifications import (
+    NotificationCreate,
+    NotificationInDB,
+    NotificationServices,
+)
+
+router = APIRouter(tags=["Notifications"])
+
+
+@router.post("/notifications", responses={status.HTTP_201_CREATED: {"model": NotificationInDB}})
+async def create_notification(
+    notification: NotificationCreate,
+    notification_services: NotificationServices = Depends(notification_composer),
+):
+    notification_in_db = await notification_services.create(notification=notification)
+    return build_response(
+        status_code=status.HTTP_201_CREATED,
+        message="Notification created with success",
+        data=notification_in_db,
+    )
+
+
+@router.patch(
+    "/notifications/{notification_id}/read",
+    responses={status.HTTP_200_OK: {"model": NotificationInDB}},
+)
+async def mark_notification_as_read(
+    notification_id: str,
+    notification_services: NotificationServices = Depends(notification_composer),
+):
+    notification_in_db = await notification_services.mark_as_read(id=notification_id)
+    return build_response(
+        status_code=status.HTTP_200_OK,
+        message="Notification marked as read",
+        data=notification_in_db,
+    )

--- a/app/api/routers/notifications/query_routers.py
+++ b/app/api/routers/notifications/query_routers.py
@@ -1,0 +1,48 @@
+from typing import List
+
+from fastapi import APIRouter, Depends, Query, status
+
+from app.api.composers import notification_composer
+from app.api.dependencies import build_response
+from app.crud.notifications import (
+    NotificationInDB,
+    NotificationServices,
+)
+
+router = APIRouter(tags=["Notifications"])
+
+
+@router.get(
+    "/notifications/{notification_id}",
+    responses={status.HTTP_200_OK: {"model": NotificationInDB}},
+)
+async def get_notification_by_id(
+    notification_id: str,
+    notification_services: NotificationServices = Depends(notification_composer),
+):
+    notification_in_db = await notification_services.search_by_id(id=notification_id)
+    return build_response(
+        status_code=status.HTTP_200_OK,
+        message="Notification found with success",
+        data=notification_in_db,
+    )
+
+
+@router.get(
+    "/notifications",
+    responses={status.HTTP_200_OK: {"model": List[NotificationInDB]}},
+)
+async def list_notifications(
+    user_id: str = Query(..., alias="userId"),
+    only_unread: bool = Query(default=False, alias="onlyUnread"),
+    notification_services: NotificationServices = Depends(notification_composer),
+):
+    notifications = await notification_services.list_by_user(
+        user_id=user_id,
+        only_unread=only_unread,
+    )
+    return build_response(
+        status_code=status.HTTP_200_OK,
+        message="Notifications retrieved with success",
+        data=notifications,
+    )

--- a/app/application.py
+++ b/app/application.py
@@ -36,7 +36,8 @@ from app.api.routers import (
     pre_order_router,
     message_router,
     additional_router,
-    business_day_router
+    business_day_router,
+    notification_router
 )
 from app.api.routers.exception_handlers import (
     unprocessable_entity_error_422,
@@ -110,6 +111,7 @@ app.include_router(coupon_router, prefix="/api")
 app.include_router(file_router, prefix="/api")
 app.include_router(marketing_email_router, prefix="/api")
 app.include_router(message_router, prefix="/api")
+app.include_router(notification_router, prefix="/api")
 app.include_router(mercado_pago_router, prefix="/api")
 app.include_router(business_day_router, prefix="/api")
 

--- a/app/crud/notifications/__init__.py
+++ b/app/crud/notifications/__init__.py
@@ -1,0 +1,13 @@
+from .schemas import (
+    NotificationChannel,
+    NotificationCreate,
+    NotificationInDB,
+)
+from .services import NotificationServices
+
+__all__ = [
+    "NotificationChannel",
+    "NotificationCreate",
+    "NotificationInDB",
+    "NotificationServices",
+]

--- a/app/crud/notifications/models.py
+++ b/app/crud/notifications/models.py
@@ -1,0 +1,35 @@
+from mongoengine import BooleanField, ListField, StringField
+
+from app.core.models.base_document import BaseDocument
+from app.core.utils.utc_datetime import UTCDateTime
+
+
+class NotificationModel(BaseDocument):
+    organization_id = StringField(required=True)
+    user_id = StringField(required=True)
+    title = StringField(required=True)
+    content = StringField(required=True)
+    channels = ListField(StringField(choices=("EMAIL", "APP")), default=list)
+    read = BooleanField(default=False)
+    notification_type = StringField(required=True)
+
+    meta = {
+        "collection": "notifications",
+        "indexes": [
+            "organization_id",
+            "user_id",
+            "notification_type",
+        ],
+    }
+
+    def update(self, **kwargs):
+        self.base_update()
+        kwargs.pop("updated_at", None)
+        return super().update(updated_at=UTCDateTime.now(), **kwargs)
+
+    def delete(self, soft_delete: bool = True, signal_kwargs=None, **write_concern):
+        if soft_delete:
+            self.soft_delete()
+            self.save()
+        else:
+            return super().delete(signal_kwargs, **write_concern)

--- a/app/crud/notifications/repositories.py
+++ b/app/crud/notifications/repositories.py
@@ -1,0 +1,137 @@
+from datetime import timedelta
+from typing import List
+
+from mongoengine.queryset.visitor import Q
+
+from app.core.configs import get_logger
+from app.core.exceptions import NotFoundError, UnprocessableEntity
+from app.core.repositories.base_repository import Repository
+from app.core.utils.utc_datetime import UTCDateTime
+
+from .models import NotificationModel
+from .schemas import NotificationCreate, NotificationInDB
+
+_logger = get_logger(__name__)
+
+
+class NotificationRepository(Repository):
+    def __init__(self, organization_id: str) -> None:
+        super().__init__()
+        self.organization_id = organization_id
+
+    async def create(self, notification: NotificationCreate) -> NotificationInDB:
+        try:
+            notification_model = NotificationModel(
+                organization_id=self.organization_id,
+                created_at=UTCDateTime.now(),
+                updated_at=UTCDateTime.now(),
+                channels=[channel.value for channel in notification.channels],
+                **notification.model_dump(exclude={"channels"}),
+            )
+            notification_model.save()
+            return await self.select_by_id(notification_model.id)
+        except Exception as error:
+            _logger.error(f"Error on create notification: {str(error)}")
+            raise UnprocessableEntity(message="Error on create notification")
+
+    async def select_by_id(self, id: str, raise_404: bool = True) -> NotificationInDB:
+        try:
+            notification_model = NotificationModel.objects(
+                id=id,
+                is_active=True,
+                organization_id=self.organization_id,
+            ).first()
+
+            if notification_model:
+                return NotificationInDB.model_validate(notification_model)
+
+            if raise_404:
+                raise NotFoundError(message=f"Notification with ID #{id} not found")
+
+        except Exception as error:
+            if raise_404:
+                raise NotFoundError(message=f"Notification with ID #{id} not found")
+            _logger.error(f"Error on select_by_id: {str(error)}")
+
+    async def select_all_by_user(
+        self,
+        user_id: str,
+        only_unread: bool = False,
+    ) -> List[NotificationInDB]:
+        try:
+            query = Q(
+                user_id=user_id,
+                is_active=True,
+                organization_id=self.organization_id,
+            )
+
+            if only_unread:
+                query &= Q(read=False)
+
+            notifications: List[NotificationInDB] = []
+            objects = NotificationModel.objects(query).order_by("-created_at")
+
+            for notification_model in objects:
+                notifications.append(NotificationInDB.model_validate(notification_model))
+
+            return notifications
+        except Exception as error:
+            _logger.error(f"Error on select_all_by_user: {str(error)}")
+            raise NotFoundError(message="Notifications not found")
+
+    async def mark_as_read(self, id: str) -> NotificationInDB:
+        try:
+            notification_model = NotificationModel.objects(
+                id=id,
+                is_active=True,
+                organization_id=self.organization_id,
+            ).first()
+
+            if not notification_model:
+                raise NotFoundError(message=f"Notification with ID #{id} not found")
+
+            notification_model.update(read=True)
+            return await self.select_by_id(id)
+        except NotFoundError:
+            raise
+        except Exception as error:
+            _logger.error(f"Error on mark_as_read: {str(error)}")
+            raise UnprocessableEntity(message="Error on mark notification as read")
+
+    async def exists_recent_notification(
+        self,
+        user_id: str,
+        notification_type: str,
+        interval: timedelta,
+    ) -> bool:
+        threshold = UTCDateTime.now() - interval
+        try:
+            notification_model = NotificationModel.objects(
+                user_id=user_id,
+                notification_type=notification_type,
+                organization_id=self.organization_id,
+                is_active=True,
+                created_at__gte=threshold,
+            ).first()
+
+            return bool(notification_model)
+        except Exception as error:
+            _logger.error(f"Error on exists_recent_notification: {str(error)}")
+            return False
+
+    async def delete_by_id(self, id: str) -> NotificationInDB:
+        try:
+            notification_model = NotificationModel.objects(
+                id=id,
+                is_active=True,
+                organization_id=self.organization_id,
+            ).first()
+
+            if notification_model:
+                notification_model.delete()
+                return NotificationInDB.model_validate(notification_model)
+
+            raise NotFoundError(message=f"Notification with ID #{id} not found")
+        except Exception as error:
+            _logger.error(f"Error on delete_by_id: {str(error)}")
+            raise NotFoundError(message=f"Notification with ID #{id} not found")

--- a/app/crud/notifications/schemas.py
+++ b/app/crud/notifications/schemas.py
@@ -1,0 +1,30 @@
+from enum import Enum
+from typing import List
+
+from pydantic import Field, field_validator
+
+from app.core.models import DatabaseModel
+from app.core.models.base_schema import GenericModel
+
+
+class NotificationChannel(str, Enum):
+    EMAIL = "EMAIL"
+    APP = "APP"
+
+
+class NotificationCreate(GenericModel):
+    user_id: str = Field(example="user_123")
+    title: str = Field(example="Pedido atualizado")
+    content: str = Field(example="Seu pedido foi enviado com sucesso!")
+    channels: List[NotificationChannel] = Field(default_factory=list, min_length=1)
+    notification_type: str = Field(example="SYSTEM_EVENT")
+
+    @field_validator("channels", mode="after")
+    @classmethod
+    def ensure_unique_channels(cls, value: List[NotificationChannel]) -> List[NotificationChannel]:
+        return list(dict.fromkeys(value))
+
+
+class NotificationInDB(NotificationCreate, DatabaseModel):
+    organization_id: str = Field(example="org_123")
+    read: bool = Field(default=False, example=False)

--- a/app/crud/notifications/services.py
+++ b/app/crud/notifications/services.py
@@ -1,0 +1,86 @@
+from datetime import timedelta
+from pathlib import Path
+from typing import List
+
+from app.api.dependencies.email_sender import send_email
+from app.core.exceptions import NotFoundError, UnprocessableEntity
+from app.core.utils.utc_datetime import UTCDateTime
+
+from .repositories import NotificationRepository
+from .schemas import NotificationChannel, NotificationCreate, NotificationInDB
+
+
+class NotificationServices:
+    def __init__(
+        self,
+        notification_repository: NotificationRepository,
+        deduplication_interval: timedelta = timedelta(minutes=10),
+        email_template_path: str = "./templates/notification-default.html",
+    ) -> None:
+        self.__notification_repository = notification_repository
+        self.__deduplication_interval = deduplication_interval
+        self.__email_template_path = Path(email_template_path)
+
+    async def create(self, notification: NotificationCreate) -> NotificationInDB:
+        exists = await self.__notification_repository.exists_recent_notification(
+            user_id=notification.user_id,
+            notification_type=notification.notification_type,
+            interval=self.__deduplication_interval,
+        )
+
+        if exists:
+            raise UnprocessableEntity(
+                message="Notification recently sent to this user with the same type"
+            )
+
+        notification_in_db = await self.__notification_repository.create(
+            notification=notification
+        )
+
+        if NotificationChannel.EMAIL in notification.channels:
+            email_body = self.__build_email_body(
+                title=notification.title,
+                content=notification.content,
+                created_at=notification_in_db.created_at,
+            )
+            send_email(
+                email_to=[notification.user_id],
+                title=notification.title,
+                message=email_body,
+            )
+
+        return notification_in_db
+
+    async def search_by_id(self, id: str) -> NotificationInDB:
+        notification_in_db = await self.__notification_repository.select_by_id(id=id)
+        if not notification_in_db:
+            raise NotFoundError(message=f"Notification with ID #{id} not found")
+        return notification_in_db
+
+    async def list_by_user(
+        self,
+        user_id: str,
+        only_unread: bool = False,
+    ) -> List[NotificationInDB]:
+        return await self.__notification_repository.select_all_by_user(
+            user_id=user_id,
+            only_unread=only_unread,
+        )
+
+    async def mark_as_read(self, id: str) -> NotificationInDB:
+        return await self.__notification_repository.mark_as_read(id=id)
+
+    async def delete_by_id(self, id: str) -> NotificationInDB:
+        return await self.__notification_repository.delete_by_id(id=id)
+
+    def __build_email_body(self, title: str, content: str, created_at: UTCDateTime) -> str:
+        if not self.__email_template_path.exists():
+            return f"<h1>{title}</h1><p>{content}</p>"
+
+        template = self.__email_template_path.read_text(encoding="utf-8")
+        return (
+            template
+            .replace("$TITLE$", title)
+            .replace("$CONTENT$", content)
+            .replace("$CREATED_AT$", str(created_at))
+        )

--- a/templates/notification-default.html
+++ b/templates/notification-default.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>$TITLE$</title>
+    <style>
+      body {
+        font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+        background-color: #f5f5f5;
+        margin: 0;
+        padding: 0;
+      }
+      .container {
+        max-width: 600px;
+        margin: 32px auto;
+        background-color: #ffffff;
+        border-radius: 12px;
+        box-shadow: 0 10px 25px rgba(0, 0, 0, 0.08);
+        overflow: hidden;
+      }
+      .header {
+        background: linear-gradient(135deg, #ff7a59 0%, #ffb347 100%);
+        padding: 24px;
+        color: #ffffff;
+        text-align: center;
+      }
+      .header h1 {
+        margin: 0;
+        font-size: 24px;
+      }
+      .content {
+        padding: 24px;
+        color: #333333;
+        line-height: 1.6;
+      }
+      .footer {
+        padding: 16px 24px 32px;
+        text-align: center;
+        font-size: 12px;
+        color: #777777;
+      }
+      .timestamp {
+        margin-top: 16px;
+        font-size: 13px;
+        color: #9b9b9b;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <div class="header">
+        <h1>$TITLE$</h1>
+      </div>
+      <div class="content">
+        <p>$CONTENT$</p>
+        <p class="timestamp">Enviado em: $CREATED_AT$</p>
+      </div>
+      <div class="footer">
+        <p>Esta é uma mensagem automática. Por favor, não responda.</p>
+      </div>
+    </div>
+  </body>
+</html>

--- a/tests/crud/notifications/test_notification_repository.py
+++ b/tests/crud/notifications/test_notification_repository.py
@@ -1,0 +1,99 @@
+import unittest
+from datetime import timedelta
+
+import mongomock
+from mongoengine import connect, disconnect
+
+from app.crud.notifications.repositories import NotificationRepository
+from app.crud.notifications.schemas import NotificationChannel, NotificationCreate
+from app.crud.notifications.models import NotificationModel
+from app.core.utils.utc_datetime import UTCDateTime
+
+
+class TestNotificationRepository(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        connect(
+            "mongoenginetest",
+            host="mongodb://localhost",
+            mongo_client_class=mongomock.MongoClient,
+            alias="default",
+        )
+        self.repository = NotificationRepository(organization_id="org_123")
+
+    def tearDown(self):
+        disconnect()
+
+    async def test_create_and_select_by_id(self):
+        notification = NotificationCreate(
+            user_id="user@example.com",
+            title="Bem-vindo",
+            content="Seu cadastro foi realizado com sucesso.",
+            channels=[NotificationChannel.EMAIL, NotificationChannel.APP],
+            notification_type="WELCOME",
+        )
+
+        created = await self.repository.create(notification=notification)
+
+        self.assertEqual(created.user_id, notification.user_id)
+        self.assertEqual(created.organization_id, "org_123")
+        self.assertEqual(set(created.channels), {NotificationChannel.EMAIL, NotificationChannel.APP})
+
+        fetched = await self.repository.select_by_id(id=created.id)
+        self.assertEqual(fetched.id, created.id)
+        self.assertFalse(fetched.read)
+
+    async def test_select_all_by_user_with_unread_filter(self):
+        notification = NotificationCreate(
+            user_id="user@example.com",
+            title="Atualização",
+            content="Seu pedido foi atualizado.",
+            channels=[NotificationChannel.APP],
+            notification_type="ORDER_UPDATE",
+        )
+
+        created = await self.repository.create(notification=notification)
+        await self.repository.mark_as_read(id=created.id)
+
+        notification_in_db = await self.repository.create(notification=notification)
+
+        all_notifications = await self.repository.select_all_by_user(user_id="user@example.com")
+        unread_notifications = await self.repository.select_all_by_user(
+            user_id="user@example.com",
+            only_unread=True,
+        )
+
+        self.assertEqual(len(all_notifications), 2)
+        self.assertEqual(len(unread_notifications), 1)
+        self.assertTrue(all(notif.read is False for notif in unread_notifications))
+
+    async def test_exists_recent_notification(self):
+        notification = NotificationCreate(
+            user_id="user@example.com",
+            title="Aviso",
+            content="Você tem uma nova mensagem.",
+            channels=[NotificationChannel.APP],
+            notification_type="ALERT",
+        )
+
+        notification_in_db = await self.repository.create(notification=notification)
+
+        exists = await self.repository.exists_recent_notification(
+            user_id="user@example.com",
+            notification_type="ALERT",
+            interval=timedelta(minutes=5),
+        )
+
+        self.assertTrue(exists)
+
+        NotificationModel.objects(id=notification_in_db.id).update(
+            set__created_at=UTCDateTime.now() - timedelta(hours=2)
+        )
+
+        exists_after_interval = await self.repository.exists_recent_notification(
+            user_id="user@example.com",
+            notification_type="ALERT",
+            interval=timedelta(hours=1),
+        )
+
+        self.assertFalse(exists_after_interval)
+

--- a/tests/crud/notifications/test_notification_services.py
+++ b/tests/crud/notifications/test_notification_services.py
@@ -1,0 +1,66 @@
+import unittest
+from datetime import timedelta
+from unittest.mock import patch
+
+import mongomock
+from mongoengine import connect, disconnect
+
+from app.core.exceptions import UnprocessableEntity
+from app.crud.notifications.repositories import NotificationRepository
+from app.crud.notifications.schemas import NotificationChannel, NotificationCreate
+from app.crud.notifications.services import NotificationServices
+
+
+class TestNotificationServices(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        connect(
+            "mongoenginetest",
+            host="mongodb://localhost",
+            mongo_client_class=mongomock.MongoClient,
+            alias="default",
+        )
+        repository = NotificationRepository(organization_id="org_123")
+        self.services = NotificationServices(
+            notification_repository=repository,
+            deduplication_interval=timedelta(minutes=30),
+            email_template_path="./templates/notification-default.html",
+        )
+
+    def tearDown(self):
+        disconnect()
+
+    @patch("app.crud.notifications.services.send_email")
+    async def test_create_notification_sends_email(self, mock_send_email):
+        notification = NotificationCreate(
+            user_id="user@example.com",
+            title="Atualização",
+            content="Seu pedido foi enviado.",
+            channels=[NotificationChannel.EMAIL],
+            notification_type="ORDER_UPDATE",
+        )
+
+        created = await self.services.create(notification=notification)
+
+        self.assertEqual(created.user_id, notification.user_id)
+        mock_send_email.assert_called_once()
+        args, kwargs = mock_send_email.call_args
+        self.assertIn("user@example.com", kwargs["email_to"])
+        self.assertEqual(kwargs["title"], notification.title)
+        self.assertIn("Seu pedido foi enviado.", kwargs["message"])
+
+    @patch("app.crud.notifications.services.send_email")
+    async def test_create_notification_deduplication(self, mock_send_email):
+        notification = NotificationCreate(
+            user_id="user@example.com",
+            title="Atualização",
+            content="Seu pedido foi enviado.",
+            channels=[NotificationChannel.EMAIL],
+            notification_type="ORDER_UPDATE",
+        )
+
+        await self.services.create(notification=notification)
+
+        with self.assertRaises(UnprocessableEntity):
+            await self.services.create(notification=notification)
+
+        mock_send_email.assert_called_once()


### PR DESCRIPTION
## Summary
- add Mongo-backed notification model, repository, service, and email template with deduplication logic
- expose notification FastAPI composer and routers for creating, listing, and marking notifications as read
- cover notification repository and service behaviours with unit tests

## Testing
- pytest tests/crud/notifications -q

------
https://chatgpt.com/codex/tasks/task_e_68db5a29aa4c832aa3dbeeb2a19b7731