### PR TITLE
Refine business day lookup window

### DIFF
--- a/tests/api/routers/business_days/test_business_day_routers.py
+++ b/tests/api/routers/business_days/test_business_day_routers.py
@@ -33,11 +33,17 @@ class TestBusinessDayRouters(unittest.TestCase):
         disconnect()
         app.dependency_overrides = {}
 
-    def create_business_day(self, closes_at: UTCDateTime | str):
+    def create_business_day(
+        self,
+        closes_at: UTCDateTime | str,
+        *,
+        day: str | None = None,
+        menu_id: str = "men_123",
+    ):
         business_day = BusinessDayModel(
             organization_id="org_123",
-            menu_id="men_123",
-            day=UTCDateTime.now().strftime("%Y-%m-%d"),
+            menu_id=menu_id,
+            day=day or UTCDateTime.now().strftime("%Y-%m-%d"),
             closes_at=UTCDateTime.validate_datetime(closes_at),
         )
         business_day.save()
@@ -62,8 +68,59 @@ class TestBusinessDayRouters(unittest.TestCase):
         self.assertIsNotNone(business_day)
         self.assertEqual(business_day.menu_id, "men_123")
 
+    def test_put_business_day_returns_400_when_closes_at_is_greater_than_one_day(self):
+        closes_at = str(UTCDateTime.now() + timedelta(days=1, minutes=1))
+
+        response = self.test_client.put(
+            url="/api/business_day",
+            json={"menu_id": "men_123", "closes_at": closes_at},
+            headers={"organization-id": "org_123"},
+        )
+
+        self.assertEqual(response.status_code, 400)
+        json = response.json()
+        self.assertEqual(
+            json["message"], "Some error happened on save business day"
+        )
+
     def test_get_business_day_returns_record(self):
         business_day = self.create_business_day(closes_at=UTCDateTime.now())
+
+        response = self.test_client.get(
+            url="/api/business_day",
+            headers={"organization-id": "org_123"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        json = response.json()
+        self.assertEqual(json["message"], "Business day found with success")
+        self.assertEqual(json["data"]["id"], str(business_day.id))
+
+    def test_get_business_day_returns_record_from_last_24_hours(self):
+        closes_at = UTCDateTime.now() - timedelta(hours=12)
+        business_day = self.create_business_day(
+            closes_at=closes_at,
+            day=(UTCDateTime.now() - timedelta(days=1)).strftime("%Y-%m-%d"),
+        )
+
+        response = self.test_client.get(
+            url="/api/business_day",
+            headers={"organization-id": "org_123"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        json = response.json()
+        self.assertEqual(json["message"], "Business day found with success")
+        self.assertEqual(json["data"]["id"], str(business_day.id))
+
+    def test_get_business_day_returns_most_recent_record_within_window(self):
+        older_closes_at = UTCDateTime.now() - timedelta(hours=6)
+        self.create_business_day(
+            closes_at=older_closes_at,
+            day=(UTCDateTime.now() - timedelta(days=1)).strftime("%Y-%m-%d"),
+        )
+        newer_closes_at = UTCDateTime.now() + timedelta(hours=6)
+        business_day = self.create_business_day(closes_at=newer_closes_at, menu_id="men_456")
 
         response = self.test_client.get(
             url="/api/business_day",


### PR DESCRIPTION
## Summary
- replace the day-scoped business day lookup with a 48-hour window around the current time and return the most recent active record
- ensure upserts reuse recent records, keep their day field in sync, and default new entries to the current day
- extend the router tests to cover the 48-hour query window and retrieval priority

## Testing
- pytest tests/api/routers/business_days/test_business_day_routers.py

------
https://chatgpt.com/codex/tasks/task_e_68e0a45b7714832abf5cdf88a6633249